### PR TITLE
Trait definition file improvement

### DIFF
--- a/brapi_to_isa.py
+++ b/brapi_to_isa.py
@@ -98,13 +98,13 @@ def create_study_sample_and_assay(client, brapi_study_id, isa_study,  sample_col
         # Getting the relevant germplasm used for that observation event:
         # ---------------------------------------------------------------
         this_source = isa_study.get_source(obs_unit['germplasmName'])
-        if this_source is not None and obs_unit['observationUnitName'] not in allready_converted_obs_unit:
+        if this_source and obs_unit['observationUnitName'] not in allready_converted_obs_unit:
             this_isa_sample = Sample(
                 name= obs_unit['observationUnitName'],
                 derives_from=[this_source])
             allready_converted_obs_unit.append(obs_unit['observationUnitName'])
             
-            obslvl = att_test(obs_unit.get('observationLevel',""))
+            obslvl = att_test(obs_unit, 'observationLevel')
             c = Characteristic(category=OntologyAnnotation(term="Observation Unit Type"),
                                 value=OntologyAnnotation(term=obslvl,
                                                                     term_source="",

--- a/brapi_to_isa_converter.py
+++ b/brapi_to_isa_converter.py
@@ -6,9 +6,9 @@ import copy
 from collections import defaultdict
 from brapi_client import BrapiClient
 
-def att_test(attribute):
-    if attribute:
-        return attribute
+def att_test(dictionary, attribute):
+    if attribute in dictionary and dictionary[attribute]:
+        return str(dictionary[attribute])
     else:
         return ""
 
@@ -116,7 +116,7 @@ class BrapiToIsaConverter:
         this_study = Study(filename="s_" + str(brapi_study_id) + ".txt")
 
         # Adding general study information
-        this_study.identifier = brapi_study.get('studyDbId', "NA")
+        this_study.identifier = brapi_study.get('studyDbId', "")
 
         if 'name' in brapi_study:
             this_study.title = brapi_study['name']
@@ -125,11 +125,11 @@ class BrapiToIsaConverter:
         else:
             this_study.title = ""
 
-        this_study.description = att_test(brapi_study.get('studyDescription', ""))
-        this_study.comments.append(Comment(name="Study Start Date", value=att_test(brapi_study.get('startDate', ""))))
-        this_study.comments.append(Comment(name="Study End Date", value=att_test(brapi_study.get('endDate', ""))))
-        this_study.comments.append(Comment(name="Study Experimental Site", value=att_test(brapi_study['location'].get('name', ""))))
-        study_design = att_test(brapi_study.get('studyType', ""))
+        this_study.description = att_test(brapi_study, 'studyDescription')
+        this_study.comments.append(Comment(name="Study Start Date", value=att_test(brapi_study, 'startDate')))
+        this_study.comments.append(Comment(name="Study End Date", value=att_test(brapi_study, 'endDate')))
+        this_study.comments.append(Comment(name="Study Experimental Site", value=att_test(brapi_study['location'], 'name')))
+        study_design = att_test(brapi_study, 'studyType')
         oa_st_design = OntologyAnnotation(term=study_design)
         this_study.design_descriptors = [oa_st_design]
         this_study.comments.append(Comment(name="Trait Definition File", value="t_" + str(brapi_study_id) + ".txt"))
@@ -149,9 +149,9 @@ class BrapiToIsaConverter:
             this_study.comments.append(
                 Comment(name="Study Country", value=""))
 
-        this_study.comments.append(Comment(name="Study Latitude", value=att_test(brapi_study['location'].get('latitude', ""))))
-        this_study.comments.append(Comment(name="Study Longitude", value=att_test(brapi_study['location'].get('longitude', ""))))
-        this_study.comments.append(Comment(name="Study Altitude",value=att_test(brapi_study['location'].get('altitude', ""))))
+        this_study.comments.append(Comment(name="Study Latitude", value=att_test(brapi_study['location'], 'latitude')))
+        this_study.comments.append(Comment(name="Study Longitude", value=att_test(brapi_study['location'], 'longitude')))
+        this_study.comments.append(Comment(name="Study Altitude",value=att_test(brapi_study['location'], 'altitude')))
 
         # Adding Contacts information
         if 'contacts' in brapi_study:
@@ -159,7 +159,7 @@ class BrapiToIsaConverter:
                 #NOTE: brapi has just name attribute -> no separate first/last name
                 ContactName = brapicontact['name'].split(' ')
                 contact = Person(first_name=ContactName[0], last_name=ContactName[1],
-                affiliation=brapicontact['institutionName'], email=brapicontact['email'])
+                affiliation=att_test(brapicontact, 'institutionName'), email=att_test(brapicontact, 'email'))
                 this_study.contacts.append(contact)
 
         # Adding dataLinks inforamtion
@@ -207,35 +207,49 @@ class BrapiToIsaConverter:
 
     def create_isa_tdf_from_obsvars(self, obsvars):
         records = []
-        header_elements = ["Variable Name", "Variable Full Name", "Variable Description", "Crop", "Growth Stage",
-                           "Date",
-                           "Method", "Method Description", "Method Formula", "Method Reference", "Scale",
-                           "Scale Data Type",
-                           "Scale Valid Values", "Unit", "Trait Name", "Trait Term REF", "Trait Class", "Trait Entity",
-                           "Trait Attribute"]
+        elements = {
+            "Variable ID": [],
+            "Variable Name": [],
+            "Trait": [],
+            "Method": [],
+            "Method Description": [],
+            "Reference Associated to the Method": [],
+            "Scale": [],
+            "Time Scale": []
+        }
 
-        tdf_header = '\t'.join(header_elements)
-        records.append(tdf_header)
+        # decorating dictionairy
+        for i, obs_var in enumerate(obsvars):
+            elements['Variable ID'].append(att_test(obs_var, 'observationVariableDbId'))
+            elements['Variable Name'].append(att_test(obs_var, 'name'))
+            elements['Trait'].append(att_test(obs_var['trait'], 'name'))
+            if att_test(obs_var['method'], 'name'):
+                elements['Method'].append(att_test(obs_var['method'], 'name'))
+            else:
+                elements['Method'].append(att_test(obs_var, 'name'))
+            if att_test(obs_var['method'], 'description'):
+                elements['Method Description'].append(att_test(obs_var['method'], 'description'))
+            else:
+                elements['Method Description'].append(att_test(obs_var['trait'], 'description'))
+            elements['Reference Associated to the Method'].append(att_test(obs_var['method'], 'reference'))
+            elements['Scale'].append(att_test(obs_var['scale'], 'name'))
+            elements['Time Scale'].append(att_test(obs_var['scale'], 'dataType'))
 
-        for obs_var in obsvars:
-            record_element = [str(obs_var['name']), str(obs_var['ontologyDbId']), str(obs_var['ontologyName']),
-                              str(obs_var['crop']),
-                              str(obs_var['growthStage']), str(
-                                  obs_var['date']), str(obs_var['method']['name']),
-                              str(obs_var['method']['description']), str(
-                                  obs_var['method']['formula']),
-                              str(obs_var['method']['reference']), str(
-                                  obs_var['scale']['name']),
-                              str(obs_var['scale']['dataType']),
-                              str(obs_var['scale']['validValues']['categories']), str(
-                                  obs_var['scale']['xref']),
-                              str(obs_var['trait']['name']), str(
-                                  obs_var['trait']['xref']),
-                              str(obs_var['trait']['class']),
-                              str(obs_var['trait']['entity']), str(obs_var['trait']['attribute'])]
-
-            record = '\t'.join(record_element)
-            records.append(record)
+        # Deleting empty columns
+        data_elements = []
+        header_elements = []
+        for key, value in elements.items():
+            if len(value) != value.count(''):
+                data_elements.append(value)
+                header_elements.append(key)
+        
+        # dumping header
+        records.append('\t'.join(header_elements))
+        # transposingdata
+        data_elements = list(map(list, zip(*data_elements)))
+        # dumping data 
+        for line in data_elements:
+            records.append('\t'.join(line))
 
         return records
 

--- a/brapi_to_isa_converter.py
+++ b/brapi_to_isa_converter.py
@@ -214,8 +214,7 @@ class BrapiToIsaConverter:
             "Method": [],
             "Method Description": [],
             "Reference Associated to the Method": [],
-            "Scale": [],
-            "Time Scale": []
+            "Scale": []
         }
 
         # decorating dictionairy
@@ -223,17 +222,19 @@ class BrapiToIsaConverter:
             elements['Variable ID'].append(att_test(obs_var, 'observationVariableDbId'))
             elements['Variable Name'].append(att_test(obs_var, 'name'))
             elements['Trait'].append(att_test(obs_var['trait'], 'name'))
+            
             if att_test(obs_var['method'], 'name'):
                 elements['Method'].append(att_test(obs_var['method'], 'name'))
             else:
                 elements['Method'].append(att_test(obs_var, 'name'))
+            
             if att_test(obs_var['method'], 'description'):
                 elements['Method Description'].append(att_test(obs_var['method'], 'description'))
             else:
                 elements['Method Description'].append(att_test(obs_var['trait'], 'description'))
+            
             elements['Reference Associated to the Method'].append(att_test(obs_var['method'], 'reference'))
             elements['Scale'].append(att_test(obs_var['scale'], 'name'))
-            elements['Time Scale'].append(att_test(obs_var['scale'], 'dataType'))
 
         # Deleting empty columns
         data_elements = []


### PR DESCRIPTION
## Examples:

t_RIGW1.txt:

| Variable ID    | Variable Name  | Trait                                            | Method          | Method Description     | Scale         | Time Scale |
|----------------|----------------|--------------------------------------------------|-----------------|------------------------|---------------|------------|
| CO_356:1000001 | BUD_DATE       | Budbreak                                         | BUD_DATE Method |                        | Calendar date | Time       |
| CO_356:1000010 | VER_50         | Veraison                                         | VER_50 Method   |                        | Calendar date | Time       |
| CO_356:1000011 | FLO_50         | Flowering                                        | FLO_50 Method   |                        | Calendar date | Time       |
| CO_356:1000053 | BERRY_TOTATERP | Concentrations of free and bound alpha-terpineol | SPE             | Solid Phase Extraction | microg/kg     | Numerical  |
| CO_356:1000054 | BERRY_TOTCITRO | Concentrations of free and bound citronellol     | SPE             | Solid Phase Extraction | microg/kg     | Numerical  |
| CO_356:1000055 | BERRY_TOTGERAN | Concentrations of free and bound geraniol        | SPE             | Solid Phase Extraction | microg/kg     | Numerical  |
| CO_356:1000056 | BERRY_TOTLIN   | Concentrations of free and bound linalool        | SPE             | Solid Phase Extraction | microg/kg     | Numerical  |
| CO_356:1000057 | BERRY_TOTNER   | Concentrations of free and bound nerol           | SPE             | Solid Phase Extraction | microg/kg     | Numerical  |

t_POPYOMICS-POP2-F.txt:

| Variable ID    | Variable Name | Trait                    | Method                       | Method Description                                                                                                                                                              | Reference Associated to the Method                                                                                                                            | Scale                              | Time Scale |
|----------------|---------------|--------------------------|------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|------------|
| CO_357:0000010 | BF_score_BL   | Budflush                 | Budflush scoring protocol    | Visual assessment on the terminal bud or on the whole tree when terminal bud is not visible with a reference scoring scale                                                      | https://forgemia.inra.fr/urgi-is/ontologies/blob/develop/Tree/T4F_D21_submitted.pdf - pages 6-20 + 30-35 for broadleaves and 45-49 + 62-64 for conifers       | Broadleaves budflush scoring scale | Nominal    |
| CO_357:0000010 | BF_score_BL   | Débourrement             | Protocole score débourrement | Evaluation à l'oeil nu selon une échelle de notation de référence sur le bourgeon apical (ou supposé apical) ou sur l'arbre entier lorsque le bourgeon apical n'est pas visible | https://forgemia.inra.fr/urgi-is/ontologies/blob/develop/Tree/T4F_D21_submitted.pdf - pages 6-20 + 30-35 pour les feuillus et 45-49 + 62-64 pour les conifers | Note de débourrement feuillus      | Nominal    |
| CO_357:0000016 | BS_date       | Budset date              | Bud date protocol            | Estimated date from polynomial regression of a time series of budflush or budset scores                                                                                         |                                                                                                                                                               | Calendar day                       | Date       |
| CO_357:0000016 | BS_date       | Date d'aoûtement         | Protocole date bourgeon      | Estimation de la date d'après une régression polynomiale réalisée sur une série temporelle de scores de débourrement ou bourgeonement                                           |                                                                                                                                                               | Jour calendaire                    | Date       |
| CO_357:0000020 | CIR1          | Tree circumference       | Ribbon 1m protocol           | Measured at 1m from the ground with a graduated ribbon                                                                                                                          | http://www.csdhub.com/national-plant-specification/conifers/nps-conifers-girth/                                                                               | mm                                 | Numerical  |
| CO_357:0000020 | CIR1          | Circonférence de l'arbre | Protocole ruban 1m           | Mesuré à 1m avec un ruban souple gradué en millimètres                                                                                                                          | http://www.csdhub.com/national-plant-specification/conifers/nps-conifers-girth/                                                                               | mm                                 | Numerical  |

t_VIB_study___40.txt:

| Variable ID | Variable Name              | Trait                      | Method                     | Method Description                                                                                              | Scale | Time Scale |
|-------------|----------------------------|----------------------------|----------------------------|-----------------------------------------------------------------------------------------------------------------|-------|------------|
| 188         | cellDivisionZoneLengthLeaf | cellDivisionZoneLengthLeaf | cellDivisionZoneLengthLeaf | size of the cell division zone at the basis of a leaf                                                           | mm    | numeric    |
| 195         | finalLeafLength            | finalLeafLength            | finalLeafLength            | length of a leaf at the end of its elongation                                                                   | mm    | numeric    |
| 60          | leafArea                   | leafArea                   | leafArea                   | a leaf anatomy and morphology trait (TO:0000748) which is associated with the total area of a leaf (PO:0025034) | mm2   | numeric    |

t_BTH_Dijon_2005_SetB1.txt:

| Variable ID  | Variable Name | Trait        | Method         | Method Description                                        | Scale | Time Scale |
|--------------|---------------|--------------|----------------|-----------------------------------------------------------|-------|------------|
| WIPO:0000074 | GY_q/ha       | Grain yield  | Direct measure | Mesure directe # ModeOp Arvalis = Récolte machine  RDT 0% | q/ha  | Numerical  |
| WIPO:0000218 | ht            | Plant height | ht             |                                                           | cm    | Numerical  |
| WIPO:0000219 | prec          | Precocity    | prec           |                                                           | d     | Duration   |
| WIPO:0000220 | ps            | Test weight  | ps             | Weight of 100 litres of grain.                            | kg/hl |            |