### PR TITLE
json conv and isa validation

### DIFF
--- a/brapi_to_isa.py
+++ b/brapi_to_isa.py
@@ -433,7 +433,7 @@ def main(arg):
                     json.dump(report, out_fp2, indent=4)
                 
                 logger.info('VALIDATION FINISHED')
-                logger.info('The ISA-TAB validation log file can be found at :' + validation_log_path)
+                logger.info('The ISA-TAB validation log file can be found at: ' + validation_log_path)
             
             except Exception as ioe:
                 logger.info('ISA-TAB validation failed!...')

--- a/brapi_to_isa_converter.py
+++ b/brapi_to_isa_converter.py
@@ -194,7 +194,7 @@ class BrapiToIsaConverter:
             if oref_tt not in investigation.ontology_source_references:
                 investigation.ontology_source_references.append(oref_tt)
 
-        print("number of ISA assays:", len(this_study.assays))
+        self.logger.info("Number of ISA assays:", len(this_study.assays))
 
         return this_study, investigation
 

--- a/brapi_to_isa_converter.py
+++ b/brapi_to_isa_converter.py
@@ -194,7 +194,7 @@ class BrapiToIsaConverter:
             if oref_tt not in investigation.ontology_source_references:
                 investigation.ontology_source_references.append(oref_tt)
 
-        self.logger.info("Number of ISA assays:" + len(this_study.assays))
+        self.logger.info("Number of ISA assays: " + str(len(this_study.assays)))
 
         return this_study, investigation
 

--- a/brapi_to_isa_converter.py
+++ b/brapi_to_isa_converter.py
@@ -194,7 +194,7 @@ class BrapiToIsaConverter:
             if oref_tt not in investigation.ontology_source_references:
                 investigation.ontology_source_references.append(oref_tt)
 
-        self.logger.info("Number of ISA assays:", len(this_study.assays))
+        self.logger.info("Number of ISA assays:" + len(this_study.assays))
 
         return this_study, investigation
 

--- a/isaconfig-phenotyping-basic/a_assay.xml
+++ b/isaconfig-phenotyping-basic/a_assay.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" ?>
+<isatab-config-file xmlns="http://www.ebi.ac.uk/bii/isatab_configuration#">
+    <isatab-configuration isatab-assay-type="generic_assay" isatab-conversion-target="generic" table-name="phenotyping_placeholdere_level">
+        <measurement source-abbreviation="" term-accession="" term-label="phenotyping"/>
+        <technology source-abbreviation="" term-accession="" term-label="placeholder level analysis"/>
+        <field data-type="String" header="Sample Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Observation unit ID) Identifier used to identify the observation unit in data files containing the values observed or measured on that unit. Must be locally unique.]]></description>
+            <default-value><![CDATA[obs_unit_X]]></default-value>
+        </field>
+        <field data-type="list" header="Characteristics[Observation Unit Type]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Experimental unit type) Type of observation unit in textual form, usually one of the following: block, sub-block, plot, plant, study, pot, replication or replicate, individual, virtual_trial, unit-parcel]]></description>
+            <list-values>placeholder,block,sub-block,plot,plant,study,pot,replicate,individual,virtual_trial,unit-parcel</list-values>
+            <default-value><![CDATA[placeholder]]></default-value>
+        </field>
+        <protocol-field protocol-type="Sampling"/>
+
+        <field data-type="String" header="Parameter Value[Collection Date]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: (Sample) Collection date) Any information not captured by the other sample fields, including quantification, sample treatments and processing.]]></description>
+            <default-value><![CDATA[e.g. 2005-08-15T15:52:01+00:00]]></default-value>
+        </field>
+        <field data-type="String" header="Parameter Value[Sample Description]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Sample description) Any information not captured by the other sample fields, including quantification, sample treatments and processing.]]></description>
+            <default-value><![CDATA[e.g. Distal part of the leaf ; 100 mg of roots taken from 10 roots at 20°C, conserved in vacuum at 20 mM NaCl salinity, stored at -60 °C to -85 °C.]]></default-value>
+        </field>
+        <field data-type="String" header="Extract Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Sample ID) Unique identifier for the sample. Description column must be given after this, holding the sample description (MIAPPE: Sample description).]]></description>
+            <default-value><![CDATA[sample_S]]></default-value>
+        </field>
+
+        <field data-type="Ontology term" header="Characteristics[Plant Structure Development Stage]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Plant structure development stage) The stage in the life of a plant structure during which the sample was taken, in the form of an accession number to a suitable controlled vocabulary (Plant Ontology, BBCH scale)]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://purl.obolibrary.org/obo/po.owl#" abbreviation="PO" name="Plant Ontology" version="2018-09-25"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="Ontology term" header="Characteristics[Plant Anatomical Entity]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Plant anatomical entity) A description of the plant part (e.g. leaf) or the plant product (e.g. resin) from which the sample was taken, in the form of an accession number to a suitable controlled vocabulary (Plant Ontology).]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://purl.obolibrary.org/obo/po.owl#" abbreviation="PO" name="Plant Ontology" version="2018-09-25"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="String" header="Characteristics[External ID]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: (Sample) External ID) An identifier for the sample in a persistent repository, comprising the name of the repository and the accession number of the observation unit therein. Submission to the EBI Biosamples repository is recommended. URI are recommended when possible.]]></description>
+                        <default-value><![CDATA[e.g. Biosamples:SAMEA4202911]]></default-value>
+        </field>
+        <protocol-field protocol-type="Phenotyping"/>
+        <field data-type="String" header="Parameter Value[Trait Definition File]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Name of the Trait definition file, holding the trait descriptions (MIAPPE: Observed Variable)]]></description>
+                        <default-value><![CDATA[e.g. tdf.txt]]></default-value>
+        </field>
+        <field data-type="String" header="Assay Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Assay Name]]></description>
+                        <default-value><![CDATA[assay_A]]></default-value>
+        </field>
+        <field data-type="String" header="Raw Data File" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Raw Data File]]></description>
+            <default-value><![CDATA[e.g. raw_data.csv]]></default-value>
+        </field>
+        <protocol-field protocol-type="Data Transformation"/>
+        <field data-type="String" header="Derived Data File" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Name of file holding the processed data.]]></description>
+                        <default-value><![CDATA[e.g. data.txt]]></default-value>
+        </field>
+        <structured-field name="factors"/>
+    </isatab-configuration>
+</isatab-config-file>

--- a/isaconfig-phenotyping-basic/i_investigation.xml
+++ b/isaconfig-phenotyping-basic/i_investigation.xml
@@ -1,0 +1,319 @@
+<?xml version="1.0" ?>
+<isatab-config-file xmlns="http://www.ebi.ac.uk/bii/isatab_configuration#">
+    <isatab-configuration table-name="i_investigation">
+        <measurement source-abbreviation="" term-accession="" term-label="[investigation]"/>
+        <technology source-abbreviation="" term-accession="" term-label=""/>
+        <field data-type="String" header="Investigation Identifier" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="INVESTIGATION">
+            <description><![CDATA[(MIAPPE: Investigation unique ID) Identifier comprising the unique name of the institution/database hosting the submission of the investigation data, and the accession number of the investigation in that institution.]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Investigation Title" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true" section="INVESTIGATION">
+            <description><![CDATA[(MIAPPE: Investigation title) Human-readable string summarising the investigation.]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Investigation Description" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="INVESTIGATION">
+            <description><![CDATA[(MIAPPE: Investigation description) Human-readable text describing the investigation in more detail.]]></description>
+            <default-value><![CDATA[e.g. The migration of maize from tropical to temperate climates was accompanied by a dramatic evolution in flowering time. To gain insight into the genetic architecture of this adaptive trait, we conducted a 50K SNP-based genome-wide association and diversity investigation on a panel of tropical and temperate American and European representatives.]]></default-value>
+        </field>
+        <field data-type="String" header="Investigation Submission Date" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="INVESTIGATION">
+            <description><![CDATA[(MIAPPE: Submission date) Date of submission of the dataset presently being described to a host repository.]]></description>
+            <default-value><![CDATA[e.g. 2012-12-17]]></default-value>
+        </field>
+        <field data-type="String" header="Investigation Public Release Date" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="INVESTIGATION">
+            <description><![CDATA[(MIAPPE: Public release date) Date of first public release of the dataset presently being described.]]></description>
+            <default-value><![CDATA[e.g. 2013-02-25]]></default-value>
+        </field>
+        <field data-type="String" header="Comment[Investigation License]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="INVESTIGATION">
+            <description><![CDATA[(MIAPPE: License) License for the reuse of the data associated with this investigation. The Creative Commons licenses cover most use cases and are recommended.]]></description>
+            <default-value><![CDATA[e.g. CC BY-SA 4.0]]></default-value>
+        </field>
+        <field data-type="String" header="Comment[MIAPPE Version]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true" section="INVESTIGATION">
+            <description><![CDATA[(MIAPPE: MIAPPE version) The version of MIAPPE used.]]></description>
+            <default-value><![CDATA[1.1]]></default-value>
+        </field>
+        <field data-type="String" header="Comment [Created With Configuration]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="INVESTIGATION">
+            <description><![CDATA[Comment [Created with configuration]]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Comment [Last Opened With Configuration]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="INVESTIGATION">
+            <description><![CDATA[Comment [Last Opened With Configuration]]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Investigation PubMed ID" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="INVESTIGATION PUBLICATIONS">
+            <description><![CDATA[Investigation PubMed ID]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Investigation Publication DOI" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="INVESTIGATION PUBLICATIONS">
+            <description><![CDATA[(MIAPPE: Associated publication) An identifier for a literature publication where the investigation is described. Use of DOIs is recommended.]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Investigation Publication Author List" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="INVESTIGATION PUBLICATIONS">
+            <description><![CDATA[Investigation Publication Author List]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Investigation Publication Title" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="INVESTIGATION PUBLICATIONS">
+            <description><![CDATA[Investigation Publication Title]]></description>
+            <default-value/>
+        </field>
+        <field data-type="Ontology term" header="Investigation Publication Status" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="INVESTIGATION PUBLICATIONS">
+            <description><![CDATA[Investigation Publication Status]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Comment[Investigation Person ID]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="INVESTIGATION CONTACTS">
+            <description><![CDATA[(MIAPPE: Person ID) An identifier for the data submitter. If that submitter is an individual, ORCID identifiers are recommended.]]></description>
+            <default-value><![CDATA[placeholder]]></default-value>
+        </field>
+        <field data-type="String" header="Investigation Person Last Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="true" section="INVESTIGATION CONTACTS">
+            <description><![CDATA[(MIAPPE: Person name) The name of the person (either full name or as used in scientific publications)]]></description>
+            <default-value><![CDATA[placeholder]]></default-value>
+        </field>
+        <field data-type="String" header="Investigation Person First Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="true" section="INVESTIGATION CONTACTS">
+            <description><![CDATA[(MIAPPE: Person name) The name of the person (either full name or as used in scientific publications)]]></description>
+            <default-value><![CDATA[placeholder]]></default-value>
+        </field>
+        <field data-type="String" header="Investigation Person Mid Initials" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="INVESTIGATION CONTACTS">
+            <description><![CDATA[(MIAPPE: Person name) The name of the person (either full name or as used in scientific publications)]]></description>
+            <default-value><![CDATA[placeholder]]></default-value>
+        </field>
+        <field data-type="String" header="Investigation Person Email" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="INVESTIGATION CONTACTS">
+            <description><![CDATA[(MIAPPE: Person email) The electronic mail address of the person.]]></description>
+            <default-value><![CDATA[placeholder]]></default-value>
+        </field>
+        <field data-type="String" header="Investigation Person Phone" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="INVESTIGATION CONTACTS">
+            <description><![CDATA[Investigation Person Phone]]></description>
+            <default-value><![CDATA[placeholder]]></default-value>
+        </field>
+        <field data-type="String" header="Investigation Person Fax" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="INVESTIGATION CONTACTS">
+            <description><![CDATA[Investigation Person Fax]]></description>
+            <default-value><![CDATA[placeholder]]></default-value>
+        </field>
+        <field data-type="String" header="Investigation Person Address" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="true" section="INVESTIGATION CONTACTS">
+            <description><![CDATA[(MIAPPE: Person affiliation) The institution the person belongs to]]></description>
+            <default-value><![CDATA[placeholder]]></default-value>
+        </field>
+        <field data-type="String" header="Investigation Person Affiliation" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="true" section="INVESTIGATION CONTACTS">
+            <description><![CDATA[(MIAPPE: Person affiliation) The institution the person belongs to]]></description>
+            <default-value><![CDATA[placeholder]]></default-value>
+        </field>
+        <field data-type="Ontology term" header="Investigation Person Roles" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="INVESTIGATION CONTACTS">
+            <description><![CDATA[(MIAPPE: Person role) Type of contribution of the person to the investigation]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Identifier" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true" section="STUDY">
+            <description><![CDATA[(MIAPPE: Study unique ID) Unique identifier comprising the name or identifier for the institution/database hosting the submission of the study data, and the identifier of the study in that institution.]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Title" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true" section="STUDY">
+            <description><![CDATA[(MIAPPE: Study title) Human-readable text summarising the study]]></description>
+            <default-value><![CDATA[e.g. 2002 evaluation of flowering time for a panel of 375 maize lines at the experimental station of Maugio (France).]]></default-value>
+        </field>
+        <field data-type="String" header="Study Description" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="STUDY">
+            <description><![CDATA[(MIAPPE: Study description) Human-readable text describing the study]]></description>
+            <default-value><![CDATA[e.g. 2002 evaluation of male and female flowering time for a panel of 375 maize lines representing the worldwide genetic diversity at the experimental station of Maugio, France.]]></default-value>
+        </field>
+        <field data-type="String" header="Comment[Study Start Date]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true" section="STUDY">
+            <description><![CDATA[(MIAPPE: Start date of study) Date and, if relevant, time when the experiment started]]></description>
+            <default-value><![CDATA[e.g. 2002-04-04]]></default-value>
+        </field>
+        <field data-type="String" header="Comment[Study End Date]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="STUDY">
+            <description><![CDATA[(MIAPPE: End date of study) Date and, if relevant, time when the experiment ende]]></description>
+            <default-value><![CDATA[e.g. 2002-11-27]]></default-value>
+        </field>
+        <field data-type="String" header="Comment[Study Contact Institution]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true" section="STUDY">
+            <description><![CDATA[(MIAPPE: Contact institution) Name and address of the institution responsible for the study.]]></description>
+            <default-value><![CDATA[e.g. UMR de Génétique Végétale, INRA – Université Paris-Sud – CNRS, Gif-sur-Yvette, France]]></default-value>
+        </field>
+        <field data-type="String" header="Comment[Study Country]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true" section="STUDY">
+            <description><![CDATA[(MIAPPE: Geographic location (country)) The country where the experiment took place, either as a full name or preferably as a 2-letter code.]]></description>
+            <default-value><![CDATA[e.g. FR]]></default-value>
+        </field>
+        <field data-type="String" header="Comment[Study Experimental Site Name]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true" section="STUDY">
+            <description><![CDATA[(MIAPPE: Experimental site name) The name of the natural site, experimental field, greenhouse, phenotyping facility, etc. where the experiment took place.]]></description>
+            <default-value><![CDATA[e.g. INRA, UE Diascope - Chemin de Mezouls - Domaine expérimental de Melgueil - 34130 Mauguio - France]]></default-value>
+        </field>
+        <field data-type="String" header="Comment[Study Latitude]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="STUDY">
+            <description><![CDATA[(MIAPPE: Geographic location (latitude)) Latitude of the experimental site in degrees, in decimal format.]]></description>
+            <default-value><![CDATA[e.g. +43.619264]]></default-value>
+        </field>
+        <field data-type="String" header="Comment[Study Longitude]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="STUDY">
+            <description><![CDATA[(MIAPPE: Geographic location (longitude)) Longititute of the experimental site in degrees, in decimal format.]]></description>
+            <default-value><![CDATA[e.g. +3.967454]]></default-value>
+        </field>
+        <field data-type="String" header="Comment[Study Altitude]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="STUDY">
+            <description><![CDATA[(MIAPPE: Geographic location (altitude)) Altitude of the experimental site, provided in metres (m).]]></description>
+            <default-value><![CDATA[e.g. 100 m]]></default-value>
+        </field>
+        <field data-type="String" header="Study Submission Date" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="STUDY">
+            <description><![CDATA[Study Submission Date]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Public Release Date" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="STUDY">
+            <description><![CDATA[Study Public Release Date]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study File Name" is-file-field="false" is-forced-ontology="false" is-hidden="true" is-multiple-value="false" is-required="true" section="STUDY">
+            <description><![CDATA[No MIAPPE equivalent, but use this field as necessary to indicate your study files.]]></description>
+            <default-value><![CDATA[]]></default-value>
+        </field>
+        <field data-type="String" header="Comment[Study Data File Link]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="STUDY">
+            <description><![CDATA[(MIAPPE: Data file link) Link to the data file (or digital object) in a public database or in a persistant institutional repository; or identifier of the data file when submitted together with the MIAPPE submission.]]></description>
+            <default-value><![CDATA[e.g. http://www.ebi.ac.uk/arrayexpress/experiments/E-GEOD-32551/]]></default-value>
+        </field>
+        <field data-type="String" header="Comment[Study Data File Description]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="STUDY">
+            <description><![CDATA[(MIAPPE: Data file description) Description of the format of the data file. May be a standard file format name, or a description of organization of the data in a tabular file.]]></description>
+            <default-value><![CDATA[e.g. FASTA, MAGE-Tab]]></default-value>
+        </field>
+        <field data-type="String" header="Comment[Study Data File Version]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="STUDY">
+            <description><![CDATA[(MIAPPE: Data file version) The version of the dataset (the actual data).]]></description>
+            <default-value><![CDATA[e.g. 1.0]]></default-value>
+        </field>
+        <field data-type="String" header="Comment[Trait Definition File]" is-file-field="true" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true" section="STUDY">
+            <description><![CDATA[(MIAPPE: name and url to Trait definition file.]]></description>
+            <default-value></default-value>
+        </field> 
+        <field data-type="String" header="Study PubMed ID" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="STUDY PUBLICATIONS">
+            <description><![CDATA[Study PubMed ID]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Publication DOI" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="STUDY PUBLICATIONS">
+            <description><![CDATA[Study Publication DOI]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Publication Author List" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="STUDY PUBLICATIONS">
+            <description><![CDATA[Study Publication Author List]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Publication Title" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="STUDY PUBLICATIONS">
+            <description><![CDATA[Study Publication Title]]></description>
+            <default-value/>
+        </field>
+        <field data-type="Ontology term" header="Study Publication Status" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="STUDY PUBLICATIONS">
+            <description><![CDATA[Study Publication Status]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Comment[Study Person ID]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="STUDY CONTACTS">
+            <description><![CDATA[(MIAPPE: Person ID) An identifier for the data submitter. If that submitter is an individual, ORCID identifiers are recommended.]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Person Last Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="STUDY CONTACTS">
+            <description><![CDATA[(MIAPPE: Person name) The name of the person (either full name or as used in scientific publications)]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Person First Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="STUDY CONTACTS">
+            <description><![CDATA[(MIAPPE: Person name) The name of the person (either full name or as used in scientific publications)]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Person Mid Initials" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="STUDY CONTACTS">
+            <description><![CDATA[(MIAPPE: Person name) The name of the person (either full name or as used in scientific publications)]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Person Email" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="STUDY CONTACTS">
+            <description><![CDATA[(MIAPPE: Person email) The electronic mail address of the person.]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Person Phone" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="STUDY CONTACTS">
+            <description><![CDATA[Study Person Phone]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Person Fax" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="STUDY CONTACTS">
+            <description><![CDATA[Study Person Fax]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Person Affiliation" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="STUDY CONTACTS">
+            <description><![CDATA[(MIAPPE: Person affiliation) The institution the person belongs to]]></description>
+            <default-value/>
+        </field>
+        <field data-type="Ontology term" header="Study Person Roles" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="STUDY CONTACTS">
+            <description><![CDATA[(MIAPPE: Person role) Type of contribution of the person to the investigation]]></description>
+            <default-value/>
+        </field>
+        <field data-type="Ontology term" header="Study Design Type" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="STUDY DESIGN DESCRIPTORS">
+            <description><![CDATA[(MIAPPE: Type of experimental design) Type of esperimental design of the study, in the form of an accession number from the Crop Ontology. Crop Ontology term (subclass of CO_715:0000003)]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://www.cropontology.org/rdf/CO_715:" abbreviation="CO_715" name="Crop Research Ontology" version="unknown"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="String" header="Comment[Study Design Description]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true" section="STUDY DESIGN DESCRIPTORS">
+            <description><![CDATA[(MIAPPE: Description of the experimental design) Short description of the experimental design, possibly including statistical design. In specific cases, e.g. legacy datasets or data computed from several studies, the experimental design can be unknown/NA, aggregated/reduced data, or simply 'none'.]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Comment[Observation Unit Level Hierarchy]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="STUDY DESIGN DESCRIPTORS">
+            <description><![CDATA[(MIAPPE: Observation unit level hierarchy) Hierarchy of the different levels of repetitions between each others]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Comment[Observation Unit Description]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true" section="STUDY DESIGN DESCRIPTORS">
+            <description><![CDATA[(MIAPPE: Observation unit description) General description of the observation units in the study.]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Comment[Map Of Experimental Design]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="STUDY DESIGN DESCRIPTORS">
+            <description><![CDATA[(MIAPPE: Map of experimental design) Representation of the experimental design.]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Factor Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="STUDY FACTORS">
+            <description><![CDATA[(MIAPPE: Experimental Factor type) Name/Acronym of the experimental factor.]]></description>
+            <default-value><![CDATA[e.g. Watering]]></default-value>
+        </field>
+        <field data-type="Ontology term" header="Study Factor Type" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true" section="STUDY FACTORS">
+            <description><![CDATA[Study Factor Type]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Comment[Study Factor Description]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="STUDY FACTORS">
+            <description><![CDATA[(MIAPPE: Experimental Factor description) Free text description of the experimental factor. This include all relevant treatments planification and protocol planed for all the plant targeted by a given experimental factor.]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Comment[Study Factor Values]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="STUDY FACTORS">
+            <description><![CDATA[(MIAPPE: Experimental Factor values) List of possible values for the factor.]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Assay Measurement Type" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="STUDY ASSAYS">
+            <description><![CDATA[No MIAPPE equivalent, but use this field as necessary.]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Assay Technology Type" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="STUDY ASSAYS">
+            <description><![CDATA[Study Assay Technology Type]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Assay Technology Platform" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false" section="STUDY ASSAYS">
+            <description><![CDATA[Study Assay Technology Platform]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Assay File Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true" section="STUDY ASSAYS">
+            <description><![CDATA[No MIAPPE equivalent, but use this field as necessary to indicate your assay files.]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Protocol Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="true" section="STUDY PROTOCOLS">
+            <description><![CDATA[Fixed protocols: Growth, Sampling (optional), Phenotyping, Data transformation. Optional: Event.]]></description>
+            <default-value/>
+        </field>
+        <field data-type="Ontology term" header="Study Protocol Type" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="true" section="STUDY PROTOCOLS">
+            <description><![CDATA[For Growth protocol: (MIAPPE) Description of growth facility. For Events: (fixed) Event. For Sampling, Phenotyping: same.]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Protocol Description" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="true" section="STUDY PROTOCOLS">
+            <description><![CDATA[For Growth protocol: (MIAPPE) Cultural practices. For Events: (MIAPPE) Event description.]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Protocol URI" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="true" section="STUDY PROTOCOLS">
+            <description><![CDATA[For Growth protocol: (MIAPPE) Type of growth facility. For Events: (MIAPPE) Event accession number.]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Protocol Version" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="true" section="STUDY PROTOCOLS">
+            <description><![CDATA[Study Protocol Version]]></description>
+            <default-value/>
+        </field>
+        <field data-type="Ontology term" header="Study Protocol Parameters Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="true" section="STUDY PROTOCOLS">
+            <description><![CDATA[For Growth: (MIAPPE) Environment Parameter. For Events: (MIAPPE - fixed) Event Date. For Phenotyping: (fixed) Trait definition file.]]></description>
+            <default-value/>
+        </field>
+        <field data-type="String" header="Study Protocol Components Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="STUDY PROTOCOLS">
+            <description><![CDATA[Study Protocol Components Name]]></description>
+            <default-value/>
+        </field>
+        <field data-type="Ontology term" header="Study Protocol Components Type" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="true" is-required="false" section="STUDY PROTOCOLS">
+            <description><![CDATA[Study Protocol Components Type]]></description>
+            <default-value/>
+        </field>
+        <structured-field name="factors"/>
+    </isatab-configuration>
+</isatab-config-file>

--- a/isaconfig-phenotyping-basic/phenotyping_block_level.xml
+++ b/isaconfig-phenotyping-basic/phenotyping_block_level.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" ?>
+<isatab-config-file xmlns="http://www.ebi.ac.uk/bii/isatab_configuration#">
+    <isatab-configuration isatab-assay-type="generic_assay" isatab-conversion-target="generic" table-name="phenotyping_block_level">
+        <measurement source-abbreviation="" term-accession="" term-label="phenotyping"/>
+        <technology source-abbreviation="" term-accession="" term-label="block level analysis"/>
+        <field data-type="String" header="Sample Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Observation unit ID) Identifier used to identify the observation unit in data files containing the values observed or measured on that unit. Must be locally unique.]]></description>
+            <default-value><![CDATA[obs_unit_X]]></default-value>
+        </field>
+        <field data-type="list" header="Characteristics[Observation Unit Type]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Experimental unit type) Type of observation unit in textual form, usually one of the following: block, sub-block, plot, plant, study, pot, replication or replicate, individual, virtual_trial, unit-parcel]]></description>
+            <list-values>block,sub-block,plot,plant,study,pot,replicate,individual,virtual_trial,unit-parcel</list-values>
+            <default-value><![CDATA[block]]></default-value>
+        </field>
+        <protocol-field protocol-type="Sampling"/>
+
+        <field data-type="String" header="Parameter Value[Collection Date]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: (Sample) Collection date) Any information not captured by the other sample fields, including quantification, sample treatments and processing.]]></description>
+            <default-value><![CDATA[e.g. 2005-08-15T15:52:01+00:00]]></default-value>
+        </field>
+        <field data-type="String" header="Parameter Value[Sample Description]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Sample description) Any information not captured by the other sample fields, including quantification, sample treatments and processing.]]></description>
+            <default-value><![CDATA[e.g. Distal part of the leaf ; 100 mg of roots taken from 10 roots at 20°C, conserved in vacuum at 20 mM NaCl salinity, stored at -60 °C to -85 °C.]]></default-value>
+        </field>
+        <field data-type="String" header="Extract Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Sample ID) Unique identifier for the sample. Description column must be given after this, holding the sample description (MIAPPE: Sample description).]]></description>
+            <default-value><![CDATA[sample_S]]></default-value>
+        </field>
+
+        <field data-type="Ontology term" header="Characteristics[Plant Structure Development Stage]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Plant structure development stage) The stage in the life of a plant structure during which the sample was taken, in the form of an accession number to a suitable controlled vocabulary (Plant Ontology, BBCH scale)]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://purl.obolibrary.org/obo/po.owl#" abbreviation="PO" name="Plant Ontology" version="2018-09-25"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="Ontology term" header="Characteristics[Plant Anatomical Entity]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Plant anatomical entity) A description of the plant part (e.g. leaf) or the plant product (e.g. resin) from which the sample was taken, in the form of an accession number to a suitable controlled vocabulary (Plant Ontology).]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://purl.obolibrary.org/obo/po.owl#" abbreviation="PO" name="Plant Ontology" version="2018-09-25"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="String" header="Characteristics[External ID]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: (Sample) External ID) An identifier for the sample in a persistent repository, comprising the name of the repository and the accession number of the observation unit therein. Submission to the EBI Biosamples repository is recommended. URI are recommended when possible.]]></description>
+                        <default-value><![CDATA[e.g. Biosamples:SAMEA4202911]]></default-value>
+        </field>
+        <protocol-field protocol-type="Phenotyping"/>
+        <field data-type="String" header="Assay Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Assay Name]]></description>
+                        <default-value><![CDATA[assay_A]]></default-value>
+        </field>
+        <field data-type="String" header="Raw Data File" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Raw Data File]]></description>
+            <default-value><![CDATA[e.g. raw_data.csv]]></default-value>
+        </field>
+        <protocol-field protocol-type="Data Transformation"/>
+        <field data-type="String" header="Derived Data File" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Name of file holding the processed data.]]></description>
+                        <default-value><![CDATA[e.g. data.txt]]></default-value>
+        </field>
+        <structured-field name="factors"/>
+    </isatab-configuration>
+</isatab-config-file>

--- a/isaconfig-phenotyping-basic/phenotyping_individual_level.xml
+++ b/isaconfig-phenotyping-basic/phenotyping_individual_level.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" ?>
+<isatab-config-file xmlns="http://www.ebi.ac.uk/bii/isatab_configuration#">
+    <isatab-configuration isatab-assay-type="generic_assay" isatab-conversion-target="generic" table-name="phenotyping_individual_level">
+        <measurement source-abbreviation="" term-accession="" term-label="phenotyping"/>
+        <technology source-abbreviation="" term-accession="" term-label="individual level analysis"/>
+        <field data-type="String" header="Sample Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Observation unit ID) Identifier used to identify the observation unit in data files containing the values observed or measured on that unit. Must be locally unique.]]></description>
+            <default-value><![CDATA[obs_unit_X]]></default-value>
+        </field>
+        <field data-type="list" header="Characteristics[Observation Unit Type]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Experimental unit type) Type of observation unit in textual form, usually one of the following: block, sub-block, plot, plant, study, pot, replication or replicate, individual, virtual_trial, unit-parcel]]></description>
+            <list-values>block,sub-block,plot,plant,study,pot,replicate,individual,virtual_trial,unit-parcel</list-values>
+            <default-value><![CDATA[individual]]></default-value>
+        </field>
+        <protocol-field protocol-type="Sampling"/>
+
+        <field data-type="String" header="Parameter Value[Collection Date]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: (Sample) Collection date) Any information not captured by the other sample fields, including quantification, sample treatments and processing.]]></description>
+            <default-value><![CDATA[e.g. 2005-08-15T15:52:01+00:00]]></default-value>
+        </field>
+        <field data-type="String" header="Parameter Value[Sample Description]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Sample description) Any information not captured by the other sample fields, including quantification, sample treatments and processing.]]></description>
+            <default-value><![CDATA[e.g. Distal part of the leaf ; 100 mg of roots taken from 10 roots at 20°C, conserved in vacuum at 20 mM NaCl salinity, stored at -60 °C to -85 °C.]]></default-value>
+        </field>
+        <field data-type="String" header="Extract Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Sample ID) Unique identifier for the sample. Description column must be given after this, holding the sample description (MIAPPE: Sample description).]]></description>
+            <default-value><![CDATA[sample_S]]></default-value>
+        </field>
+
+        <field data-type="Ontology term" header="Characteristics[Plant Structure Development Stage]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Plant structure development stage) The stage in the life of a plant structure during which the sample was taken, in the form of an accession number to a suitable controlled vocabulary (Plant Ontology, BBCH scale)]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://purl.obolibrary.org/obo/po.owl#" abbreviation="PO" name="Plant Ontology" version="2018-09-25"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="Ontology term" header="Characteristics[Plant Anatomical Entity]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Plant anatomical entity) A description of the plant part (e.g. leaf) or the plant product (e.g. resin) from which the sample was taken, in the form of an accession number to a suitable controlled vocabulary (Plant Ontology).]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://purl.obolibrary.org/obo/po.owl#" abbreviation="PO" name="Plant Ontology" version="2018-09-25"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="String" header="Characteristics[External ID]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: (Sample) External ID) An identifier for the sample in a persistent repository, comprising the name of the repository and the accession number of the observation unit therein. Submission to the EBI Biosamples repository is recommended. URI are recommended when possible.]]></description>
+                        <default-value><![CDATA[e.g. Biosamples:SAMEA4202911]]></default-value>
+        </field>
+        <protocol-field protocol-type="Phenotyping"/>
+        <field data-type="String" header="Assay Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Assay Name]]></description>
+                        <default-value><![CDATA[assay_A]]></default-value>
+        </field>
+        <field data-type="String" header="Raw Data File" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Raw Data File]]></description>
+            <default-value><![CDATA[e.g. raw_data.csv]]></default-value>
+        </field>
+        <protocol-field protocol-type="Data Transformation"/>
+        <field data-type="String" header="Derived Data File" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Name of file holding the processed data.]]></description>
+                        <default-value><![CDATA[e.g. data.txt]]></default-value>
+        </field>
+        <structured-field name="factors"/>
+    </isatab-configuration>
+</isatab-config-file>

--- a/isaconfig-phenotyping-basic/phenotyping_plant_level.xml
+++ b/isaconfig-phenotyping-basic/phenotyping_plant_level.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" ?>
+<isatab-config-file xmlns="http://www.ebi.ac.uk/bii/isatab_configuration#">
+    <isatab-configuration isatab-assay-type="generic_assay" isatab-conversion-target="generic" table-name="phenotyping_plant_level">
+        <measurement source-abbreviation="" term-accession="" term-label="phenotyping"/>
+        <technology source-abbreviation="" term-accession="" term-label="plant level analysis"/>
+        <field data-type="String" header="Sample Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Observation unit ID) Identifier used to identify the observation unit in data files containing the values observed or measured on that unit. Must be locally unique.]]></description>
+            <default-value><![CDATA[obs_unit_X]]></default-value>
+        </field>
+        <field data-type="list" header="Characteristics[Observation Unit Type]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Experimental unit type) Type of observation unit in textual form, usually one of the following: block, sub-block, plot, plant, study, pot, replication or replicate, individual, virtual_trial, unit-parcel]]></description>
+            <list-values>block,sub-block,plot,plant,study,pot,replicate,individual,virtual_trial,unit-parcel</list-values>
+            <default-value><![CDATA[plant]]></default-value>
+        </field>
+        <protocol-field protocol-type="Sampling"/>
+
+        <field data-type="String" header="Parameter Value[Collection Date]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: (Sample) Collection date) Any information not captured by the other sample fields, including quantification, sample treatments and processing.]]></description>
+            <default-value><![CDATA[e.g. 2005-08-15T15:52:01+00:00]]></default-value>
+        </field>
+        <field data-type="String" header="Parameter Value[Sample Description]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Sample description) Any information not captured by the other sample fields, including quantification, sample treatments and processing.]]></description>
+            <default-value><![CDATA[e.g. Distal part of the leaf ; 100 mg of roots taken from 10 roots at 20°C, conserved in vacuum at 20 mM NaCl salinity, stored at -60 °C to -85 °C.]]></default-value>
+        </field>
+        <field data-type="String" header="Extract Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Sample ID) Unique identifier for the sample. Description column must be given after this, holding the sample description (MIAPPE: Sample description).]]></description>
+            <default-value><![CDATA[sample_S]]></default-value>
+        </field>
+
+        <field data-type="Ontology term" header="Characteristics[Plant Structure Development Stage]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Plant structure development stage) The stage in the life of a plant structure during which the sample was taken, in the form of an accession number to a suitable controlled vocabulary (Plant Ontology, BBCH scale)]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://purl.obolibrary.org/obo/po.owl#" abbreviation="PO" name="Plant Ontology" version="2018-09-25"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="Ontology term" header="Characteristics[Plant Anatomical Entity]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Plant anatomical entity) A description of the plant part (e.g. leaf) or the plant product (e.g. resin) from which the sample was taken, in the form of an accession number to a suitable controlled vocabulary (Plant Ontology).]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://purl.obolibrary.org/obo/po.owl#" abbreviation="PO" name="Plant Ontology" version="2018-09-25"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="String" header="Characteristics[External ID]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: (Sample) External ID) An identifier for the sample in a persistent repository, comprising the name of the repository and the accession number of the observation unit therein. Submission to the EBI Biosamples repository is recommended. URI are recommended when possible.]]></description>
+                        <default-value><![CDATA[e.g. Biosamples:SAMEA4202911]]></default-value>
+        </field>
+        <protocol-field protocol-type="Phenotyping"/>
+        <field data-type="String" header="Assay Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Assay Name]]></description>
+                        <default-value><![CDATA[assay_A]]></default-value>
+        </field>
+        <field data-type="String" header="Raw Data File" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Raw Data File]]></description>
+            <default-value><![CDATA[e.g. raw_data.csv]]></default-value>
+        </field>
+        <protocol-field protocol-type="Data Transformation"/>
+        <field data-type="String" header="Derived Data File" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Name of file holding the processed data.]]></description>
+                        <default-value><![CDATA[e.g. data.txt]]></default-value>
+        </field>
+        <structured-field name="factors"/>
+    </isatab-configuration>
+</isatab-config-file>

--- a/isaconfig-phenotyping-basic/phenotyping_plot_level.xml
+++ b/isaconfig-phenotyping-basic/phenotyping_plot_level.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" ?>
+<isatab-config-file xmlns="http://www.ebi.ac.uk/bii/isatab_configuration#">
+    <isatab-configuration isatab-assay-type="generic_assay" isatab-conversion-target="generic" table-name="phenotyping_plot_level">
+        <measurement source-abbreviation="" term-accession="" term-label="phenotyping"/>
+        <technology source-abbreviation="" term-accession="" term-label="plot level analysis"/>
+        <field data-type="String" header="Sample Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Observation unit ID) Identifier used to identify the observation unit in data files containing the values observed or measured on that unit. Must be locally unique.]]></description>
+            <default-value><![CDATA[obs_unit_X]]></default-value>
+        </field>
+        <field data-type="list" header="Characteristics[Observation Unit Type]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Experimental unit type) Type of observation unit in textual form, usually one of the following: block, sub-block, plot, plant, study, pot, replication or replicate, individual, virtual_trial, unit-parcel]]></description>
+            <list-values>block,sub-block,plot,plant,study,pot,replicate,individual,virtual_trial,unit-parcel</list-values>
+            <default-value><![CDATA[plot]]></default-value>
+        </field>
+        <protocol-field protocol-type="Sampling"/>
+
+        <field data-type="String" header="Parameter Value[Collection Date]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: (Sample) Collection date) Any information not captured by the other sample fields, including quantification, sample treatments and processing.]]></description>
+            <default-value><![CDATA[e.g. 2005-08-15T15:52:01+00:00]]></default-value>
+        </field>
+        <field data-type="String" header="Parameter Value[Sample Description]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Sample description) Any information not captured by the other sample fields, including quantification, sample treatments and processing.]]></description>
+            <default-value><![CDATA[e.g. Distal part of the leaf ; 100 mg of roots taken from 10 roots at 20°C, conserved in vacuum at 20 mM NaCl salinity, stored at -60 °C to -85 °C.]]></default-value>
+        </field>
+        <field data-type="String" header="Extract Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Sample ID) Unique identifier for the sample. Description column must be given after this, holding the sample description (MIAPPE: Sample description).]]></description>
+            <default-value><![CDATA[sample_S]]></default-value>
+        </field>
+
+        <field data-type="Ontology term" header="Characteristics[Plant Structure Development Stage]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Plant structure development stage) The stage in the life of a plant structure during which the sample was taken, in the form of an accession number to a suitable controlled vocabulary (Plant Ontology, BBCH scale)]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://purl.obolibrary.org/obo/po.owl#" abbreviation="PO" name="Plant Ontology" version="2018-09-25"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="Ontology term" header="Characteristics[Plant Anatomical Entity]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Plant anatomical entity) A description of the plant part (e.g. leaf) or the plant product (e.g. resin) from which the sample was taken, in the form of an accession number to a suitable controlled vocabulary (Plant Ontology).]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://purl.obolibrary.org/obo/po.owl#" abbreviation="PO" name="Plant Ontology" version="2018-09-25"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="String" header="Characteristics[External ID]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: (Sample) External ID) An identifier for the sample in a persistent repository, comprising the name of the repository and the accession number of the observation unit therein. Submission to the EBI Biosamples repository is recommended. URI are recommended when possible.]]></description>
+                        <default-value><![CDATA[e.g. Biosamples:SAMEA4202911]]></default-value>
+        </field>
+        <protocol-field protocol-type="Phenotyping"/>
+        <field data-type="String" header="Assay Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Assay Name]]></description>
+                        <default-value><![CDATA[assay_A]]></default-value>
+        </field>
+        <field data-type="String" header="Raw Data File" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Raw Data File]]></description>
+            <default-value><![CDATA[e.g. raw_data.csv]]></default-value>
+        </field>
+        <protocol-field protocol-type="Data Transformation"/>
+        <field data-type="String" header="Derived Data File" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Name of file holding the processed data.]]></description>
+                        <default-value><![CDATA[e.g. data.txt]]></default-value>
+        </field>
+        <structured-field name="factors"/>
+    </isatab-configuration>
+</isatab-config-file>

--- a/isaconfig-phenotyping-basic/phenotyping_pot_level.xml
+++ b/isaconfig-phenotyping-basic/phenotyping_pot_level.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" ?>
+<isatab-config-file xmlns="http://www.ebi.ac.uk/bii/isatab_configuration#">
+    <isatab-configuration isatab-assay-type="generic_assay" isatab-conversion-target="generic" table-name="phenotyping_pot_level">
+        <measurement source-abbreviation="" term-accession="" term-label="phenotyping"/>
+        <technology source-abbreviation="" term-accession="" term-label="pot level analysis"/>
+        <field data-type="String" header="Sample Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Observation unit ID) Identifier used to identify the observation unit in data files containing the values observed or measured on that unit. Must be locally unique.]]></description>
+            <default-value><![CDATA[obs_unit_X]]></default-value>
+        </field>
+        <field data-type="list" header="Characteristics[Observation Unit Type]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Experimental unit type) Type of observation unit in textual form, usually one of the following: block, sub-block, plot, plant, study, pot, replication or replicate, individual, virtual_trial, unit-parcel]]></description>
+            <list-values>block,sub-block,plot,plant,study,pot,replicate,individual,virtual_trial,unit-parcel</list-values>
+            <default-value><![CDATA[pot]]></default-value>
+        </field>
+        <protocol-field protocol-type="Sampling"/>
+
+        <field data-type="String" header="Parameter Value[Collection Date]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: (Sample) Collection date) Any information not captured by the other sample fields, including quantification, sample treatments and processing.]]></description>
+            <default-value><![CDATA[e.g. 2005-08-15T15:52:01+00:00]]></default-value>
+        </field>
+        <field data-type="String" header="Parameter Value[Sample Description]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Sample description) Any information not captured by the other sample fields, including quantification, sample treatments and processing.]]></description>
+            <default-value><![CDATA[e.g. Distal part of the leaf ; 100 mg of roots taken from 10 roots at 20°C, conserved in vacuum at 20 mM NaCl salinity, stored at -60 °C to -85 °C.]]></default-value>
+        </field>
+        <field data-type="String" header="Extract Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Sample ID) Unique identifier for the sample. Description column must be given after this, holding the sample description (MIAPPE: Sample description).]]></description>
+            <default-value><![CDATA[sample_S]]></default-value>
+        </field>
+
+        <field data-type="Ontology term" header="Characteristics[Plant Structure Development Stage]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Plant structure development stage) The stage in the life of a plant structure during which the sample was taken, in the form of an accession number to a suitable controlled vocabulary (Plant Ontology, BBCH scale)]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://purl.obolibrary.org/obo/po.owl#" abbreviation="PO" name="Plant Ontology" version="2018-09-25"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="Ontology term" header="Characteristics[Plant Anatomical Entity]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Plant anatomical entity) A description of the plant part (e.g. leaf) or the plant product (e.g. resin) from which the sample was taken, in the form of an accession number to a suitable controlled vocabulary (Plant Ontology).]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://purl.obolibrary.org/obo/po.owl#" abbreviation="PO" name="Plant Ontology" version="2018-09-25"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="String" header="Characteristics[External ID]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: (Sample) External ID) An identifier for the sample in a persistent repository, comprising the name of the repository and the accession number of the observation unit therein. Submission to the EBI Biosamples repository is recommended. URI are recommended when possible.]]></description>
+                        <default-value><![CDATA[e.g. Biosamples:SAMEA4202911]]></default-value>
+        </field>
+        <protocol-field protocol-type="Phenotyping"/>
+        <field data-type="String" header="Assay Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Assay Name]]></description>
+                        <default-value><![CDATA[assay_A]]></default-value>
+        </field>
+        <field data-type="String" header="Raw Data File" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Raw Data File]]></description>
+            <default-value><![CDATA[e.g. raw_data.csv]]></default-value>
+        </field>
+        <protocol-field protocol-type="Data Transformation"/>
+        <field data-type="String" header="Derived Data File" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Name of file holding the processed data.]]></description>
+                        <default-value><![CDATA[e.g. data.txt]]></default-value>
+        </field>
+        <structured-field name="factors"/>
+    </isatab-configuration>
+</isatab-config-file>

--- a/isaconfig-phenotyping-basic/phenotyping_replicate_level.xml
+++ b/isaconfig-phenotyping-basic/phenotyping_replicate_level.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" ?>
+<isatab-config-file xmlns="http://www.ebi.ac.uk/bii/isatab_configuration#">
+    <isatab-configuration isatab-assay-type="generic_assay" isatab-conversion-target="generic" table-name="phenotyping_replicate_level">
+        <measurement source-abbreviation="" term-accession="" term-label="phenotyping"/>
+        <technology source-abbreviation="" term-accession="" term-label="replication or replicate level analysis"/>
+        <field data-type="String" header="Sample Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Observation unit ID) Identifier used to identify the observation unit in data files containing the values observed or measured on that unit. Must be locally unique.]]></description>
+            <default-value><![CDATA[obs_unit_X]]></default-value>
+        </field>
+        <field data-type="list" header="Characteristics[Observation Unit Type]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Experimental unit type) Type of observation unit in textual form, usually one of the following: block, sub-block, plot, plant, study, pot, replication or replicate, individual, virtual_trial, unit-parcel]]></description>
+            <list-values> block,sub-block,plot,plant,study,pot,replicate,individual,virtual_trial,unit-parcel</list-values>
+            <default-value><![CDATA[replicate]]></default-value>
+        </field>
+        <protocol-field protocol-type="Sampling"/>
+
+        <field data-type="String" header="Parameter Value[Collection Date]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: (Sample) Collection date) Any information not captured by the other sample fields, including quantification, sample treatments and processing.]]></description>
+            <default-value><![CDATA[e.g. 2005-08-15T15:52:01+00:00]]></default-value>
+        </field>
+        <field data-type="String" header="Parameter Value[Sample Description]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Sample description) Any information not captured by the other sample fields, including quantification, sample treatments and processing.]]></description>
+            <default-value><![CDATA[e.g. Distal part of the leaf ; 100 mg of roots taken from 10 roots at 20°C, conserved in vacuum at 20 mM NaCl salinity, stored at -60 °C to -85 °C.]]></default-value>
+        </field>
+        <field data-type="String" header="Extract Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Sample ID) Unique identifier for the sample. Description column must be given after this, holding the sample description (MIAPPE: Sample description).]]></description>
+            <default-value><![CDATA[sample_S]]></default-value>
+        </field>
+
+        <field data-type="Ontology term" header="Characteristics[Plant Structure Development Stage]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Plant structure development stage) The stage in the life of a plant structure during which the sample was taken, in the form of an accession number to a suitable controlled vocabulary (Plant Ontology, BBCH scale)]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://purl.obolibrary.org/obo/po.owl#" abbreviation="PO" name="Plant Ontology" version="2018-09-25"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="Ontology term" header="Characteristics[Plant Anatomical Entity]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Plant anatomical entity) A description of the plant part (e.g. leaf) or the plant product (e.g. resin) from which the sample was taken, in the form of an accession number to a suitable controlled vocabulary (Plant Ontology).]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://purl.obolibrary.org/obo/po.owl#" abbreviation="PO" name="Plant Ontology" version="2018-09-25"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="String" header="Characteristics[External ID]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: (Sample) External ID) An identifier for the sample in a persistent repository, comprising the name of the repository and the accession number of the observation unit therein. Submission to the EBI Biosamples repository is recommended. URI are recommended when possible.]]></description>
+                        <default-value><![CDATA[e.g. Biosamples:SAMEA4202911]]></default-value>
+        </field>
+        <protocol-field protocol-type="Phenotyping"/>
+        <field data-type="String" header="Assay Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Assay Name]]></description>
+                        <default-value><![CDATA[assay_A]]></default-value>
+        </field>
+        <field data-type="String" header="Raw Data File" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Raw Data File]]></description>
+            <default-value><![CDATA[e.g. raw_data.csv]]></default-value>
+        </field>
+        <protocol-field protocol-type="Data Transformation"/>
+        <field data-type="String" header="Derived Data File" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Name of file holding the processed data.]]></description>
+                        <default-value><![CDATA[e.g. data.txt]]></default-value>
+        </field>
+        <structured-field name="factors"/>
+    </isatab-configuration>
+</isatab-config-file>

--- a/isaconfig-phenotyping-basic/phenotyping_study_level.xml
+++ b/isaconfig-phenotyping-basic/phenotyping_study_level.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" ?>
+<isatab-config-file xmlns="http://www.ebi.ac.uk/bii/isatab_configuration#">
+    <isatab-configuration isatab-assay-type="generic_assay" isatab-conversion-target="generic" table-name="phenotyping_study_level">
+        <measurement source-abbreviation="" term-accession="" term-label="phenotyping"/>
+        <technology source-abbreviation="" term-accession="" term-label="study level analysis"/>
+        <field data-type="String" header="Sample Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Observation unit ID) Identifier used to identify the observation unit in data files containing the values observed or measured on that unit. Must be locally unique.]]></description>
+            <default-value><![CDATA[obs_unit_X]]></default-value>
+        </field>
+        <field data-type="list" header="Characteristics[Observation Unit Type]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Experimental unit type) Type of observation unit in textual form, usually one of the following: block, sub-block, plot, plant, study, pot, replication or replicate, individual, virtual_trial, unit-parcel]]></description>
+            <list-values>block,sub-block,plot,plant,study,pot,replicate,individual,virtual_trial,unit-parcel</list-values>
+            <default-value><![CDATA[study]]></default-value>
+        </field>
+        <protocol-field protocol-type="Sampling"/>
+
+        <field data-type="String" header="Parameter Value[Collection Date]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: (Sample) Collection date) Any information not captured by the other sample fields, including quantification, sample treatments and processing.]]></description>
+            <default-value><![CDATA[e.g. 2005-08-15T15:52:01+00:00]]></default-value>
+        </field>
+        <field data-type="String" header="Parameter Value[Sample Description]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Sample description) Any information not captured by the other sample fields, including quantification, sample treatments and processing.]]></description>
+            <default-value><![CDATA[e.g. Distal part of the leaf ; 100 mg of roots taken from 10 roots at 20°C, conserved in vacuum at 20 mM NaCl salinity, stored at -60 °C to -85 °C.]]></default-value>
+        </field>
+        <field data-type="String" header="Extract Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Sample ID) Unique identifier for the sample. Description column must be given after this, holding the sample description (MIAPPE: Sample description).]]></description>
+            <default-value><![CDATA[sample_S]]></default-value>
+        </field>
+
+        <field data-type="Ontology term" header="Characteristics[Plant Structure Development Stage]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Plant structure development stage) The stage in the life of a plant structure during which the sample was taken, in the form of an accession number to a suitable controlled vocabulary (Plant Ontology, BBCH scale)]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://purl.obolibrary.org/obo/po.owl#" abbreviation="PO" name="Plant Ontology" version="2018-09-25"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="Ontology term" header="Characteristics[Plant Anatomical Entity]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Plant anatomical entity) A description of the plant part (e.g. leaf) or the plant product (e.g. resin) from which the sample was taken, in the form of an accession number to a suitable controlled vocabulary (Plant Ontology).]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://purl.obolibrary.org/obo/po.owl#" abbreviation="PO" name="Plant Ontology" version="2018-09-25"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="String" header="Characteristics[External ID]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: (Sample) External ID) An identifier for the sample in a persistent repository, comprising the name of the repository and the accession number of the observation unit therein. Submission to the EBI Biosamples repository is recommended. URI are recommended when possible.]]></description>
+                        <default-value><![CDATA[e.g. Biosamples:SAMEA4202911]]></default-value>
+        </field>
+        <protocol-field protocol-type="Phenotyping"/>
+        <field data-type="String" header="Assay Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Assay Name]]></description>
+                        <default-value><![CDATA[assay_A]]></default-value>
+        </field>
+        <field data-type="String" header="Raw Data File" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Raw Data File]]></description>
+            <default-value><![CDATA[e.g. raw_data.csv]]></default-value>
+        </field>
+        <protocol-field protocol-type="Data Transformation"/>
+        <field data-type="String" header="Derived Data File" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Name of file holding the processed data.]]></description>
+                        <default-value><![CDATA[e.g. data.txt]]></default-value>
+        </field>
+        <structured-field name="factors"/>
+    </isatab-configuration>
+</isatab-config-file>

--- a/isaconfig-phenotyping-basic/phenotyping_sub-block_level.xml
+++ b/isaconfig-phenotyping-basic/phenotyping_sub-block_level.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" ?>
+<isatab-config-file xmlns="http://www.ebi.ac.uk/bii/isatab_configuration#">
+    <isatab-configuration isatab-assay-type="generic_assay" isatab-conversion-target="generic" table-name="phenotyping_sub-block_level">
+        <measurement source-abbreviation="" term-accession="" term-label="phenotyping"/>
+        <technology source-abbreviation="" term-accession="" term-label="sub-block level analysis"/>
+        <field data-type="String" header="Sample Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Observation unit ID) Identifier used to identify the observation unit in data files containing the values observed or measured on that unit. Must be locally unique.]]></description>
+            <default-value><![CDATA[obs_unit_X]]></default-value>
+        </field>
+        <field data-type="list" header="Characteristics[Observation Unit Type]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Experimental unit type) Type of observation unit in textual form, usually one of the following: block, sub-block, plot, plant, study, pot, replication or replicate, individual, virtual_trial, unit-parcel]]></description>
+            <list-values>block,sub-block,plot,plant,study,pot,replicate,individual,virtual_trial,unit-parcel</list-values>
+            <default-value><![CDATA[sub-block]]></default-value>
+        </field>
+        <protocol-field protocol-type="Sampling"/>
+
+        <field data-type="String" header="Parameter Value[Collection Date]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: (Sample) Collection date) Any information not captured by the other sample fields, including quantification, sample treatments and processing.]]></description>
+            <default-value><![CDATA[e.g. 2005-08-15T15:52:01+00:00]]></default-value>
+        </field>
+        <field data-type="String" header="Parameter Value[Sample Description]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Sample description) Any information not captured by the other sample fields, including quantification, sample treatments and processing.]]></description>
+            <default-value><![CDATA[e.g. Distal part of the leaf ; 100 mg of roots taken from 10 roots at 20°C, conserved in vacuum at 20 mM NaCl salinity, stored at -60 °C to -85 °C.]]></default-value>
+        </field>
+        <field data-type="String" header="Extract Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Sample ID) Unique identifier for the sample. Description column must be given after this, holding the sample description (MIAPPE: Sample description).]]></description>
+            <default-value><![CDATA[sample_S]]></default-value>
+        </field>
+
+        <field data-type="Ontology term" header="Characteristics[Plant Structure Development Stage]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Plant structure development stage) The stage in the life of a plant structure during which the sample was taken, in the form of an accession number to a suitable controlled vocabulary (Plant Ontology, BBCH scale)]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://purl.obolibrary.org/obo/po.owl#" abbreviation="PO" name="Plant Ontology" version="2018-09-25"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="Ontology term" header="Characteristics[Plant Anatomical Entity]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Plant anatomical entity) A description of the plant part (e.g. leaf) or the plant product (e.g. resin) from which the sample was taken, in the form of an accession number to a suitable controlled vocabulary (Plant Ontology).]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://purl.obolibrary.org/obo/po.owl#" abbreviation="PO" name="Plant Ontology" version="2018-09-25"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="String" header="Characteristics[External ID]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: (Sample) External ID) An identifier for the sample in a persistent repository, comprising the name of the repository and the accession number of the observation unit therein. Submission to the EBI Biosamples repository is recommended. URI are recommended when possible.]]></description>
+                        <default-value><![CDATA[e.g. Biosamples:SAMEA4202911]]></default-value>
+        </field>
+        <protocol-field protocol-type="Phenotyping"/>
+        <field data-type="String" header="Assay Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Assay Name]]></description>
+                        <default-value><![CDATA[assay_A]]></default-value>
+        </field>
+        <field data-type="String" header="Raw Data File" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Raw Data File]]></description>
+            <default-value><![CDATA[e.g. raw_data.csv]]></default-value>
+        </field>
+        <protocol-field protocol-type="Data Transformation"/>
+        <field data-type="String" header="Derived Data File" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Name of file holding the processed data.]]></description>
+                        <default-value><![CDATA[e.g. data.txt]]></default-value>
+        </field>
+        <structured-field name="factors"/>
+    </isatab-configuration>
+</isatab-config-file>

--- a/isaconfig-phenotyping-basic/phenotyping_unit-parcel_level.xml
+++ b/isaconfig-phenotyping-basic/phenotyping_unit-parcel_level.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" ?>
+<isatab-config-file xmlns="http://www.ebi.ac.uk/bii/isatab_configuration#">
+    <isatab-configuration isatab-assay-type="generic_assay" isatab-conversion-target="generic" table-name="phenotyping_unit-parcel_level">
+        <measurement source-abbreviation="" term-accession="" term-label="phenotyping"/>
+        <technology source-abbreviation="" term-accession="" term-label="unit-parcel level analysis"/>
+        <field data-type="String" header="Sample Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Observation unit ID) Identifier used to identify the observation unit in data files containing the values observed or measured on that unit. Must be locally unique.]]></description>
+            <default-value><![CDATA[obs_unit_X]]></default-value>
+        </field>
+        <field data-type="list" header="Characteristics[Observation Unit Type]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Experimental unit type) Type of observation unit in textual form, usually one of the following: block, sub-block, plot, plant, study, pot, replication or replicate, individual, virtual_trial, unit-parcel]]></description>
+            <list-values>block,sub-block,plot,plant,study,pot,replicate,individual,virtual_trial,unit-parcel</list-values>
+            <default-value><![CDATA[unit-parcel]]></default-value>
+        </field>
+        <protocol-field protocol-type="Sampling"/>
+
+        <field data-type="String" header="Parameter Value[Collection Date]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: (Sample) Collection date) Any information not captured by the other sample fields, including quantification, sample treatments and processing.]]></description>
+            <default-value><![CDATA[e.g. 2005-08-15T15:52:01+00:00]]></default-value>
+        </field>
+        <field data-type="String" header="Parameter Value[Sample Description]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Sample description) Any information not captured by the other sample fields, including quantification, sample treatments and processing.]]></description>
+            <default-value><![CDATA[e.g. Distal part of the leaf ; 100 mg of roots taken from 10 roots at 20°C, conserved in vacuum at 20 mM NaCl salinity, stored at -60 °C to -85 °C.]]></default-value>
+        </field>
+        <field data-type="String" header="Extract Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Sample ID) Unique identifier for the sample. Description column must be given after this, holding the sample description (MIAPPE: Sample description).]]></description>
+            <default-value><![CDATA[sample_S]]></default-value>
+        </field>
+
+        <field data-type="Ontology term" header="Characteristics[Plant Structure Development Stage]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Plant structure development stage) The stage in the life of a plant structure during which the sample was taken, in the form of an accession number to a suitable controlled vocabulary (Plant Ontology, BBCH scale)]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://purl.obolibrary.org/obo/po.owl#" abbreviation="PO" name="Plant Ontology" version="2018-09-25"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="Ontology term" header="Characteristics[Plant Anatomical Entity]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Plant anatomical entity) A description of the plant part (e.g. leaf) or the plant product (e.g. resin) from which the sample was taken, in the form of an accession number to a suitable controlled vocabulary (Plant Ontology).]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://purl.obolibrary.org/obo/po.owl#" abbreviation="PO" name="Plant Ontology" version="2018-09-25"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="String" header="Characteristics[External ID]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: (Sample) External ID) An identifier for the sample in a persistent repository, comprising the name of the repository and the accession number of the observation unit therein. Submission to the EBI Biosamples repository is recommended. URI are recommended when possible.]]></description>
+                        <default-value><![CDATA[e.g. Biosamples:SAMEA4202911]]></default-value>
+        </field>
+        <protocol-field protocol-type="Phenotyping"/>
+        <field data-type="String" header="Assay Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Assay Name]]></description>
+                        <default-value><![CDATA[assay_A]]></default-value>
+        </field>
+        <field data-type="String" header="Raw Data File" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Raw Data File]]></description>
+            <default-value><![CDATA[e.g. raw_data.csv]]></default-value>
+        </field>
+        <protocol-field protocol-type="Data Transformation"/>
+        <field data-type="String" header="Derived Data File" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Name of file holding the processed data.]]></description>
+                        <default-value><![CDATA[e.g. data.txt]]></default-value>
+        </field>
+        <structured-field name="factors"/>
+    </isatab-configuration>
+</isatab-config-file>

--- a/isaconfig-phenotyping-basic/phenotyping_virtual_trial_level.xml
+++ b/isaconfig-phenotyping-basic/phenotyping_virtual_trial_level.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" ?>
+<isatab-config-file xmlns="http://www.ebi.ac.uk/bii/isatab_configuration#">
+    <isatab-configuration isatab-assay-type="generic_assay" isatab-conversion-target="generic" table-name="phenotyping_virtual_trial_level">
+        <measurement source-abbreviation="" term-accession="" term-label="phenotyping"/>
+        <technology source-abbreviation="" term-accession="" term-label="virtual_trial level analysis"/>
+        <field data-type="String" header="Sample Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Observation unit ID) Identifier used to identify the observation unit in data files containing the values observed or measured on that unit. Must be locally unique.]]></description>
+            <default-value><![CDATA[obs_unit_X]]></default-value>
+        </field>
+        <field data-type="list" header="Characteristics[Observation Unit Type]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Experimental unit type) Type of observation unit in textual form, usually one of the following: block, sub-block, plot, plant, study, pot, replication or replicate, individual, virtual_trial, unit-parcel]]></description>
+            <list-values>block,sub-block,plot,plant,study,pot,replicate,individual,virtual_trial,unit-parcel</list-values>
+            <default-value><![CDATA[virtual_trial]]></default-value>
+        </field>
+        <protocol-field protocol-type="Sampling"/>
+
+        <field data-type="String" header="Parameter Value[Collection Date]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: (Sample) Collection date) Any information not captured by the other sample fields, including quantification, sample treatments and processing.]]></description>
+            <default-value><![CDATA[e.g. 2005-08-15T15:52:01+00:00]]></default-value>
+        </field>
+        <field data-type="String" header="Parameter Value[Sample Description]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Sample description) Any information not captured by the other sample fields, including quantification, sample treatments and processing.]]></description>
+            <default-value><![CDATA[e.g. Distal part of the leaf ; 100 mg of roots taken from 10 roots at 20°C, conserved in vacuum at 20 mM NaCl salinity, stored at -60 °C to -85 °C.]]></default-value>
+        </field>
+        <field data-type="String" header="Extract Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Sample ID) Unique identifier for the sample. Description column must be given after this, holding the sample description (MIAPPE: Sample description).]]></description>
+            <default-value><![CDATA[sample_S]]></default-value>
+        </field>
+
+        <field data-type="Ontology term" header="Characteristics[Plant Structure Development Stage]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Plant structure development stage) The stage in the life of a plant structure during which the sample was taken, in the form of an accession number to a suitable controlled vocabulary (Plant Ontology, BBCH scale)]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://purl.obolibrary.org/obo/po.owl#" abbreviation="PO" name="Plant Ontology" version="2018-09-25"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="Ontology term" header="Characteristics[Plant Anatomical Entity]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Plant anatomical entity) A description of the plant part (e.g. leaf) or the plant product (e.g. resin) from which the sample was taken, in the form of an accession number to a suitable controlled vocabulary (Plant Ontology).]]></description>
+            <default-value/>
+            <recommended-ontologies>
+                <ontology id="http://purl.obolibrary.org/obo/po.owl#" abbreviation="PO" name="Plant Ontology" version="2018-09-25"/>
+            </recommended-ontologies>
+        </field>
+        <field data-type="String" header="Characteristics[External ID]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: (Sample) External ID) An identifier for the sample in a persistent repository, comprising the name of the repository and the accession number of the observation unit therein. Submission to the EBI Biosamples repository is recommended. URI are recommended when possible.]]></description>
+                        <default-value><![CDATA[e.g. Biosamples:SAMEA4202911]]></default-value>
+        </field>
+        <protocol-field protocol-type="Phenotyping"/>
+        <field data-type="String" header="Assay Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Assay Name]]></description>
+                        <default-value><![CDATA[assay_A]]></default-value>
+        </field>
+        <field data-type="String" header="Raw Data File" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Raw Data File]]></description>
+            <default-value><![CDATA[e.g. raw_data.csv]]></default-value>
+        </field>
+        <protocol-field protocol-type="Data Transformation"/>
+        <field data-type="String" header="Derived Data File" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[Name of file holding the processed data.]]></description>
+                        <default-value><![CDATA[e.g. data.txt]]></default-value>
+        </field>
+        <structured-field name="factors"/>
+    </isatab-configuration>
+</isatab-config-file>

--- a/isaconfig-phenotyping-basic/s_study_basic.xml
+++ b/isaconfig-phenotyping-basic/s_study_basic.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" ?>
+<isatab-config-file xmlns="http://www.ebi.ac.uk/bii/isatab_configuration#">
+    <isatab-configuration table-name="s_study">
+        <measurement source-abbreviation="" term-accession="" term-label="[Sample]"/>
+        <technology source-abbreviation="" term-accession="" term-label=""/>
+        <field data-type="String" header="Source Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Biological Material ID) Code used to identify the biological material in the data file. Should be unique within the Investigation. Can correspond to experimental plant ID, seed lot ID, etc… This material identification is different from a BiosampleID which corresponds to Observation Unit or Samples sections below.]]></description>
+            <default-value><![CDATA[biological-material_A]]></default-value>
+        </field>
+        <field data-type="string" header="Characteristics[Organism]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Organism) An identifier for the organism at the species level. Use of the NCBI taxon ID is recommended.]]></description>
+            <default-value><![CDATA[e.g. NCBI:4577]]></default-value>
+        </field>
+        <field data-type="String" header="Characteristics[Genus]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Genus) Genus name for the organism under study, according to standard scientific nomenclature.]]></description>
+            <default-value><![CDATA[e.g. Zea]]></default-value>
+        </field>
+        <field data-type="String" header="Characteristics[Species]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Species) Species name (formally: specific epithet) for the organism under study, according to standard scientific nomenclature.]]></description>
+            <default-value><![CDATA[e.g. mays]]></default-value>
+        </field>
+        <field data-type="String" header="Characteristics[Infraspecific Name]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Infraspecific name) Name of any subtaxa level, including variety, crossing name, etc. It can be used to store any additional taxonomic identifier. Either free text description or key-value pair list format (the key is the name of the rank and the value is the value of the rank). Ranks can be among the following terms: subspecies, cultivar, variety, subvariety, convariety, group, subgroup, hybrid, line, form, subform. For MCPD compliance, the following abbreviations are allowed: ‘subsp.’ (subspecies); ‘convar.’ (convariety); ‘var.’ (variety); ‘f.’ (form); ‘Group’ (cultivar group).]]></description>
+            <default-value><![CDATA[e.g. var:B73]]></default-value>
+        </field>
+        <field data-type="String" header="Characteristics[Biological Material Latitude]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Biological material latitude) Latitude of the studied biological material. [Alternative identifier for in situ material]]]></description>
+            <default-value><![CDATA[e.g. +39.067]]></default-value>
+        </field>
+        <field data-type="String" header="Characteristics[Biological Material Longitude]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Biological material longitude) Latitude of the studied biological material. [Alternative identifier for in situ material]]]></description>
+            <default-value><![CDATA[e.g. -8.73]]></default-value>
+        </field>
+        <field data-type="String" header="Characteristics[Biological Material Altitude]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Biological Material altitude) Altitude of the studied biological material, provided in meters (m). [Alternative identifier for in situ material]]]></description>
+            <default-value><![CDATA[e.g. 10]]></default-value>
+        </field>
+        <unit-field data-type="String" is-forced-ontology="false" is-multiple-value="false" is-required="false">
+            <default-value><![CDATA[meter]]></default-value>
+            <description>Unit abbreviation for Biological material altitude.</description>
+        </unit-field>
+        <field data-type="String" header="Characteristics[Biological Material Coordinates Uncertainty]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Biological material coordinates uncertainty) Circular uncertainty of the coordinates, preferably provided in meters (m). [Alternative identifier for in situ material]]]></description>
+            <default-value><![CDATA[e.g. 200]]></default-value>
+        </field>
+        <unit-field data-type="String" is-forced-ontology="false" is-multiple-value="false" is-required="false">
+            <default-value><![CDATA[meter]]></default-value>
+            <description>Unit abbreviation for Biological material coordinates uncertainty.&quot;</description>
+        </unit-field>
+        <field data-type="String" header="Characteristics[Biological Material Preprocessing]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Biological material preprocessing) Description of any process or treatment applied uniformly to the biological material, prior to the study itself. Can be provided as free text or as an accession number from a suitable controlled vocabulary.]]></description>
+            <default-value><![CDATA[e.g. EO:0007210 - PVY(NTN); transplanted from study http://phenome-fppn.fr/maugio/2013/t2351 observation unit ID: pot:894]]></default-value>
+        </field>
+        <field data-type="String" header="Characteristics[Material Source ID]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Material source ID (Holding institute/stock centre, accession) An identifier for the source of the biological material, in the form of a key-value pair comprising the name/identifier of the repository from which the material was sourced plus the accession number of the repository for that material. Where an accession number has not been assigned, but the material has been derived from the crossing of known accessions, the material can be defined as follows: mother_accession X father_accession, or, if father is unknown, as mother_accession X UNKNOWN. For in situ material, the region of provenance may be used when an accession is not available.]]></description>
+            <default-value><![CDATA[e.g. ICNF:PNB-RPI]]></default-value>
+        </field>
+        <field data-type="String" header="Characteristics[Material Source DOI]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Material source DOI) Digital Object Identifier (DOI) of the material source]]></description>
+            <default-value><![CDATA[e.g. doi:10.15454/1.4658436467893904E12]]></default-value>
+        </field>
+        <field data-type="String" header="Characteristics[Material Source Latitude]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Material source latitude) Latitude of the material source. [Alternative identifier for in situ material]]]></description>
+            <default-value><![CDATA[e.g. +39.067]]></default-value>
+        </field>
+        <field data-type="String" header="Characteristics[Material Source Longitude]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Material source longitude) Longitude of the material source. [Alternative identifier for in situ material]]]></description>
+            <default-value><![CDATA[e.g. -8.73]]></default-value>
+        </field>
+        <field data-type="String" header="Characteristics[Material Source Altitude]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Material source altitude) Altitude of the material source, provided in metres (m). [Alternative identifier for in situ material]]]></description>
+            <default-value><![CDATA[e.g. 10]]></default-value>
+        </field>
+        <unit-field data-type="String" is-forced-ontology="false" is-multiple-value="false" is-required="false">
+            <default-value><![CDATA[meter]]></default-value>
+            <description>Unit abbreviation for Material source altitude</description>
+        </unit-field>
+        <field data-type="String" header="Characteristics[Material Source Coordinates Uncertainty]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Material source coordinates uncertainty) Circular uncertainty of the coordinates, provided in meters (m). [Alternative identifier for in situ material]]]></description>
+            <default-value><![CDATA[e.g. 200]]></default-value>
+        </field>
+        <unit-field data-type="String" is-forced-ontology="false" is-multiple-value="false" is-required="false">
+            <default-value><![CDATA[meter]]></default-value>
+            <description>Unit abbreviation for Material source coordinates uncertainty.</description>
+        </unit-field>
+        <field data-type="String" header="Characteristics[Material Source Description]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Material source description) Description of the material source]]></description>
+            <default-value><![CDATA[e.g. Branches were collected from a 10-year-old tree growing in a progeny trial established in a loamy brown earth soil.]]></default-value>
+        </field>
+        <protocol-field protocol-type="Growth"/>
+        <field data-type="String" header="Sample Name" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Observation unit ID) Identifier used to identify the observation unit in data files containing the values observed or measured on that unit. Must be locally unique.]]></description>
+            <default-value><![CDATA[e.g. obs_unit_B]]></default-value>
+        </field>
+        <field data-type="list" header="Characteristics[Observation Unit Type]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="true">
+            <description><![CDATA[(MIAPPE: Observation unit type) Type of observation unit in textual form, usually one of the following: block, sub-block, plot, plant, trial, pot, replication or replicate, individual, virtual_trial, unit-parcel]]></description>
+            <default-value><![CDATA[plant]]></default-value>
+            <list-values>block,sub-block,plot,plant,trial,pot,replicate,individual,virtual_trial,unit-parcel</list-values>
+        </field>
+        <field data-type="String" header="Characteristics[External ID]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: External ID) Identifier for the observation unit in a persistent repository, comprises the name of the repository and the identifier of the observation unit therein. The EBI Biosamples repository can be used. URI are recommended when possible.]]></description>
+            <default-value><![CDATA[e.g. Biosamples:SAMEA4202911]]></default-value>
+        </field>
+        <field data-type="String" header="Characteristics[Spatial Distribution]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Spatial distribution) Type and value of a spatial coordinate (georeference or relative) or level of observation (plot 45, subblock 7, block 2) provided as a key-value pair of the form type:value. Levels of observation must be consistent with those listed in the Study section.]]></description>
+            <default-value><![CDATA[e.g. Latitude:+2.341; row:4 ; X:3; Y:6; Xm:35; Ym:65; Block:1; Plot:894]]></default-value>
+        </field>
+        <field data-type="String" header="Factor Value[e.g. Watering]" is-file-field="false" is-forced-ontology="false" is-hidden="false" is-multiple-value="false" is-required="false">
+            <description><![CDATA[(MIAPPE: Observation Unit factor value) List of values for each factor applied to the observation unit - one per column, for the respective factor name.]]></description>
+            <default-value><![CDATA[e.g. watered]]></default-value>
+        </field>
+        <structured-field name="characteristics"/>
+        <structured-field name="factors"/>
+    </isatab-configuration>
+</isatab-config-file>


### PR DESCRIPTION
- Incorporated JSON dump by converting the isa tab files 
-> can be disabled by adding the -J or --json flag to the command 
- Incorporated isa-tab validation 
-> can be disabled by adding the -V or --validation flag to the command
-> configuration files based on MIAPPE 1.1 https://github.com/MIAPPE/ISA-Tab-for-plant-phenotyping/tree/v1.1

So both functions are enabled by default.