### PR TITLE
Add setup.py to consume BrAPI2ISA as a python package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+setup(
+    name='BrAPI2ISA',
+    url='https://github.com/elixir-europe/plant-brapi-to-isa',
+    packages=['.'],
+    install_requires=open('requirements.txt').read().splitlines(),
+    version='0.1',
+    description='Convert BrAPI data to ISA',
+    long_description=open('README.md').read(),
+)


### PR DESCRIPTION
I'm adding a `setup.py` to be able to use this program as a python pip package.

Once merged, everyone can install the package with:
`pip install git+ssh://git@github.com:elixir-europe/plant-brapi-to-isa.git@<REF>#egg=brapi2isa`
> Where `<REF>` is the git tag or branch or commit

And then it can just be imported with 
`import brapi_to_isa`

