### PR TITLE
NCBI Taxon ID optimalisation 

### DIFF
--- a/brapi_to_isa.py
+++ b/brapi_to_isa.py
@@ -147,16 +147,22 @@ def create_study_sample_and_assay(client, brapi_study_id, isa_study,  growth_pro
             # Looking for treatment in BRAPI and mapping to ISA samples 
             # ---------------------------------------------------------
             if att_test(obs_unit, 'treatments'):
+                treatmentbuffer = defaultdict(list)
                 for treatment in obs_unit['treatments']:
                     if att_test(treatment,'factor') and att_test(treatment, 'modality'):
-                        if treatment['modality'] not in treatments[treatment['factor']]:
-                            treatments[treatment['factor']].append(treatment['modality'])
-                        f = StudyFactor(name=treatment['factor'], factor_type=OntologyAnnotation(term=treatment['factor']))
-                        fv = FactorValue(factor_name=f,
-                                        value=OntologyAnnotation(term=str(treatment['modality']),
-                                                                term_source="",
-                                                                term_accession=""))
-                        this_isa_sample.factor_values.append(fv)
+
+                        if str(treatment['modality']) not in treatmentbuffer[treatment['factor']]:
+                            treatmentbuffer[treatment['factor']].append(str(treatment['modality']))
+                for factor,modality in treatmentbuffer.items():
+                    modalities = ','.join(modality)
+                    if modalities not in treatments[factor]:
+                        treatments[factor].append(modalities)
+                    f = StudyFactor(name=factor, factor_type=OntologyAnnotation(term=factor))
+                    fv = FactorValue(factor_name=f,
+                                    value=OntologyAnnotation(term=modalities,
+                                                            term_source="",
+                                                            term_accession=""))
+                    this_isa_sample.factor_values.append(fv)
             isa_study.samples.append(this_isa_sample)
 
             # Creating the corresponding ISA sample entity for structure the document:

--- a/brapi_to_isa.py
+++ b/brapi_to_isa.py
@@ -130,7 +130,7 @@ def create_study_sample_and_assay(client, brapi_study_id, isa_study,  growth_pro
                 if att_test(obs_unit,key):
                     spat_dist.append(spat_dist_mapping_dictionary[key] + ':' + obs_unit[key])
             if att_test(obs_unit,'observationLevels'):
-                for lvl in obs_unit['observationLevels'].split(","):
+                for lvl in obs_unit['observationLevels'].split(", "):
                     if len(lvl.split(":")) == 2:    
                         a, b = lvl.split(":")
                         spat_dist.append(a + ':' + b)

--- a/brapi_to_isa.py
+++ b/brapi_to_isa.py
@@ -128,7 +128,7 @@ def create_study_sample_and_assay(client, brapi_study_id, isa_study,  growth_pro
             spat_dist = []
             for key in spat_dist_mapping_dictionary:
                 if att_test(obs_unit,key):
-                    spat_dist.append('[' + spat_dist_mapping_dictionary[key] + ']' + obs_unit[key])
+                    spat_dist.append(spat_dist_mapping_dictionary[key] + ':' + obs_unit[key])
             if att_test(obs_unit,'observationLevels'):
                 for lvl in obs_unit['observationLevels'].split(","):
                     if len(lvl.split(":")) == 2:    
@@ -136,7 +136,7 @@ def create_study_sample_and_assay(client, brapi_study_id, isa_study,  growth_pro
                         spat_dist.append(a + ':' + b)
                     elif len(lvl.split(":")) == 1:
                         spat_dist.append(lvl)
-            spat_dist_str = '; '.join(spat_dist)
+            spat_dist_str = ';'.join(spat_dist)
             if spat_dist:
                 c = Characteristic(category=OntologyAnnotation(term="Spatial Distribution"),
                                     value=OntologyAnnotation(term=spat_dist_str,

--- a/brapi_to_isa_converter.py
+++ b/brapi_to_isa_converter.py
@@ -85,20 +85,27 @@ class BrapiToIsaConverter:
             c = self.create_isa_characteristic('Organism', ';'.join(taxonids))
             returned_characteristics.append(c)
         else:
-            if ('genus' in all_germplasm_attributes and all_germplasm_attributes['genus']) or ('species' in all_germplasm_attributes and all_germplasm_attributes['species']):
+            if att_test(all_germplasm_attributes,'genus') or att_test(all_germplasm_attributes,'species'):
                 taxonId = self._brapi_client.get_taxonId(all_germplasm_attributes['genus'],all_germplasm_attributes['species'])
+                organism = ""
+                if att_test(all_germplasm_attributes,'genus') and att_test(all_germplasm_attributes,'species'):
+                    organism = all_germplasm_attributes['genus'] + ' ' + all_germplasm_attributes['species']
+                else:
+                    organism = att_test(all_germplasm_attributes,'genus') + att_test(all_germplasm_attributes,'species')
                 if taxonId:
-                    c = self.create_isa_characteristic(
-                        'Organism', 'NCBI:'+ str(taxonId))
+                    ncbitaxon = OntologySource(name='NCBITaxon', description="NCBI Taxonomy")
+                    c = Characteristic(category=OntologyAnnotation(term="Organism"),
+                                     value=OntologyAnnotation(term=organism, term_source=ncbitaxon,
+                                                              term_accession="http://purl.bioontology.org/ontology/NCBITAXON/{}".format(taxonId)))
                     
                 else:
-                    if 'commonCropName' in all_germplasm_attributes and all_germplasm_attributes['commonCropName']:
+                    if att_test(all_germplasm_attributes, 'commonCropName'):
                         c = self.create_isa_characteristic('Organism', all_germplasm_attributes['commonCropName'])
                     else:
                         c = self.create_isa_characteristic('Organism', "")
 
             else:
-                if 'commonCropName' in all_germplasm_attributes and all_germplasm_attributes['commonCropName']:
+                if att_test(all_germplasm_attributes,'commonCropName'):
                     c = self.create_isa_characteristic('Organism', all_germplasm_attributes['commonCropName'])
                 else:
                     c = self.create_isa_characteristic('Organism', "")

--- a/brapi_to_isa_converter.py
+++ b/brapi_to_isa_converter.py
@@ -99,16 +99,10 @@ class BrapiToIsaConverter:
                                                               term_accession="http://purl.bioontology.org/ontology/NCBITAXON/{}".format(taxonId)))
                     
                 else:
-                    if att_test(all_germplasm_attributes, 'commonCropName'):
-                        c = self.create_isa_characteristic('Organism', all_germplasm_attributes['commonCropName'])
-                    else:
-                        c = self.create_isa_characteristic('Organism', "")
+                    c = self.create_isa_characteristic('Organism', att_test(all_germplasm_attributes, 'commonCropName'), PAR_NAinData)
 
             else:
-                if att_test(all_germplasm_attributes,'commonCropName'):
-                    c = self.create_isa_characteristic('Organism', all_germplasm_attributes['commonCropName'])
-                else:
-                    c = self.create_isa_characteristic('Organism', "")
+                c = self.create_isa_characteristic('Organism', att_test(all_germplasm_attributes,'commonCropName'), PAR_NAinData)
             returned_characteristics.append(c)
         
         mapping_dictionnary = {
@@ -121,13 +115,8 @@ class BrapiToIsaConverter:
 
 
         for key in mapping_dictionnary:
-            if att_test(all_germplasm_attributes,'key'):
-                c = self.create_isa_characteristic(
-                        mapping_dictionnary[key], str(all_germplasm_attributes[key]))
-            else:
-                c = self.create_isa_characteristic(
-                    mapping_dictionnary[key], "")
-            
+            c = self.create_isa_characteristic(
+                    mapping_dictionnary[key], str(att_test(all_germplasm_attributes,'key')))
             returned_characteristics.append(c)
 
         return returned_characteristics

--- a/brapi_to_isa_converter.py
+++ b/brapi_to_isa_converter.py
@@ -79,27 +79,10 @@ class BrapiToIsaConverter:
         #Checking if taxonId is supplied or not, otherwise fetch it from www.ebi.ac.uk
         if not taxonId or not taxonId.isdigit():
             taxonId = self._brapi_client.get_taxonId(genus, species)
-
-        # Determining the Organism
-        organism = ""
-        if genus and species:
-            organism = genus + ' ' + species
-        elif genus or species:
-            organism = genus + species
-
-        # making the characteristic based on the NCBI taxon Id or commonCropName
-        if taxonId and organism:
-            ncbitaxon = OntologySource(
-                name='NCBITaxon', description="NCBI Taxonomy")
-            #ncbitaxon can be URI or NCBI ID, if ID it is assumed to be an integer
-            my_term_accession = "http://purl.bioontology.org/ontology/NCBITAXON/{}".format(
-                taxonId)
-
-            return self.create_isa_characteristic('Organism', "NCBI:{}".format(str(taxonId))), Characteristic(category=OntologyAnnotation(term="NCBI"),
-                                                                                                              value=OntologyAnnotation(term=organism, term_source=ncbitaxon,
-                                                                                                                                       term_accession=my_term_accession))
+        if taxonId:
+            return self.create_isa_characteristic('Organism', "NCBITAXON:{}".format(str(taxonId)))
         else:
-            return self.create_isa_characteristic('Organism', att_test(all_germplasm_attributes, 'commonCropName', PAR_NAinData)), ""
+            return self.create_isa_characteristic('Organism', att_test(all_germplasm_attributes, 'commonCropName', PAR_NAinData))
 
     def create_germplasm_chars(self, germplasm):
         """" Given a BRAPI Germplasm ID, retrieve the list of all attributes from BRAPI and returns a list of ISA
@@ -116,16 +99,13 @@ class BrapiToIsaConverter:
             taxonId = ''
             for taxonid in all_germplasm_attributes['taxonIds']:
                 if taxonid['sourceName'] in ['NCBITaxon', 'ncbiTaxon']:
-                    c1, c2 = self.organism_characteristic(
+                    c = self.organism_characteristic(
                         all_germplasm_attributes, taxonid['taxonId'])
-            if c2:
-                returned_characteristics.append(c2)
-            returned_characteristics.append(c1)
+            returned_characteristics.append(c)
+            
         else:
-            c1, c2 = self.organism_characteristic(all_germplasm_attributes, "")
-            if c2:
-                returned_characteristics.append(c2)
-            returned_characteristics.append(c1)
+            c = self.organism_characteristic(all_germplasm_attributes, "")
+            returned_characteristics.append(c)
 
         mapping_dictionnary = {
             "genus": "Genus",

--- a/brapi_to_isa_converter.py
+++ b/brapi_to_isa_converter.py
@@ -9,6 +9,8 @@ import re
 
 def att_test(dictionary, attribute, NA=""):
     if attribute in dictionary and dictionary[attribute]:
+        if dictionary[attribute] in ['NA', 'na','Na', 'n.a.', 'N.A.', 'N.a.']:
+            return NA
         return str(dictionary[attribute])
     else:
         return NA

--- a/brapi_to_isa_converter.py
+++ b/brapi_to_isa_converter.py
@@ -78,7 +78,7 @@ class BrapiToIsaConverter:
         all_germplasm_attributes = self._brapi_client.get_germplasm(
             germplasm_id)
 
-        if 'taxonId' in all_germplasm_attributes and all_germplasm_attributes['taxonId']:
+        if att_test(all_germplasm_attributes,'taxonId'):
             taxonids =[]
             for taxonid in all_germplasm_attributes['taxonId']:
                 taxonids.append(att_test(taxonid, 'sourceName', 'NCBI') + ":" + str(taxonid['taxonId']))
@@ -121,7 +121,7 @@ class BrapiToIsaConverter:
 
 
         for key in mapping_dictionnary:
-            if key in all_germplasm_attributes and all_germplasm_attributes[key]:
+            if att_test(all_germplasm_attributes,'key'):
                 c = self.create_isa_characteristic(
                         mapping_dictionnary[key], str(all_germplasm_attributes[key]))
             else:

--- a/brapi_to_isa_converter.py
+++ b/brapi_to_isa_converter.py
@@ -116,7 +116,7 @@ class BrapiToIsaConverter:
 
         for key in mapping_dictionnary:
             c = self.create_isa_characteristic(
-                    mapping_dictionnary[key], str(att_test(all_germplasm_attributes,'key')))
+                    mapping_dictionnary[key], str(att_test(all_germplasm_attributes,key)))
             returned_characteristics.append(c)
 
         return returned_characteristics

--- a/brapi_to_isa_converter.py
+++ b/brapi_to_isa_converter.py
@@ -122,6 +122,7 @@ class BrapiToIsaConverter:
             returned_characteristics.append(c)
         else:
             c = self.organism_characteristic(all_germplasm_attributes, "")
+            returned_characteristics.append(c)
 
         
         mapping_dictionnary = {


### PR DESCRIPTION
New format:

| Source Name                  | Characteristics[Organism] | Term Source REF | Term Accession Number                                | Characteristics[Genus] | Characteristics[Species] | Characteristics[Material Source ID] | Protocol REF | Sample Name | Characteristics[Observation Unit Type] | Characteristics[Spatial Distribution]       |
|------------------------------|---------------------------|-----------------|------------------------------------------------------|------------------------|--------------------------|-------------------------------------|--------------|-------------|----------------------------------------|---------------------------------------------|
| Cork oak Barradas daSerra 03 | Quercus suber             | NCBITaxon       | http://purl.bioontology.org/ontology/NCBITAXON/58331 | Quercus                | suber                    | INIAV:BS03                          | Growth       | BS3         | plantnumber                            | [block]1; [plot]1; [plant]BS3; [replicate]1 |
| Corkoak Barradas da Serra 04 | Quercus suber             | NCBITaxon       | http://purl.bioontology.org/ontology/NCBITAXON/58331 | Quercus                | suber                    | INIAV:BS04                          | Growth       | BS4         | plantnumber                            | [block]1; [plot]1; [plant]BS4; [replicate]2 |
| Corkoak Barradas da Serra 05 | Quercus suber             | NCBITaxon       | http://purl.bioontology.org/ontology/NCBITAXON/58331 | Quercus                | suber                    | INIAV:BS05                          | Growth       | BS5         | plantnumber                            | [block]1; [plot]1; [plant]BS5; [replicate]3 |
| Corkoak Barradas da Serra 06 | Quercus suber             | NCBITaxon       | http://purl.bioontology.org/ontology/NCBITAXON/58331 | Quercus                | suber                    | INIAV:BS06                          | Growth       | BS6         | plantnumber                            | [block]1; [plot]1; [plant]BS6; [replicate]4 |


Source Name | Characteristics[Organism] | Term Source REF | Term Accession Number | Characteristics[Genus] | Characteristics[Species] | Characteristics[Material Source ID] | Characteristics[Material Source DOI] | Protocol REF | Sample Name | Characteristics[Observation Unit Type] | Characteristics[Spatial Distribution] | Factor Value[fruit load]
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
<i>S. lycopersicum</i> cv. M82 | Solanum lycopersicum | NCBITaxon | http://purl.bioontology.org/ontology/NCBITAXON/4081 | Solanum | lycopersicum | EA10004 | https://www.eu-sol.wur.nl/rdf/accession/EA10004 | Growth | 29301054 | plant | [X]1054; [plot]0; [plant]29301054; [replicate]1 | low (pruned till one fruit)
<i>S. lycopersicum</i> cv. M82 | Solanum lycopersicum | NCBITaxon | http://purl.bioontology.org/ontology/NCBITAXON/4081 | Solanum | lycopersicum | EA10004 | https://www.eu-sol.wur.nl/rdf/accession/EA10004 | Growth | 29301618 | plant | [X]1618; [plot]0; [plant]29301618; [replicate]1 | low (pruned till one fruit)
<i>S. lycopersicum</i> cv. M82 | Solanum lycopersicum | NCBITaxon | http://purl.bioontology.org/ontology/NCBITAXON/4081 | Solanum | lycopersicum | EA10004 | https://www.eu-sol.wur.nl/rdf/accession/EA10004 | Growth | 29301030 | plant | [X]1030; [plot]0; [plant]29301030; [replicate]1 | low (pruned till one fruit)
<i>S. lycopersicum</i> cv. M82 | Solanum lycopersicum | NCBITaxon | http://purl.bioontology.org/ontology/NCBITAXON/4081 | Solanum | lycopersicum | EA10004 | https://www.eu-sol.wur.nl/rdf/accession/EA10004 | Growth | 29302127 | plant | [X]2127; [plot]0; [plant]29302127; [replicate]1 | low (pruned till one fruit)



generated with:
```
python brapi_to_isa.py -e https://brapi.biodata.pt/brapi/v1/ -t 2
python brapi_to_isa.py -e https://www.eu-sol.wur.nl/webapi/tomato/brapi/v1/ -t 2
```