### PR TITLE
Datatable fix + windows filename problem

### DIFF
--- a/brapi_to_isa.py
+++ b/brapi_to_isa.py
@@ -280,7 +280,7 @@ def get_empty_trial():
     yield from [empty_trial]
 
 
-def main(arg):
+def main(arg=SERVER):
     """ Given a SERVER value (and BRAPI isa_study identifier), generates an ISA-Tab document"""
 
     client = BrapiClient(SERVER, logger)
@@ -484,7 +484,7 @@ def main(arg):
 """ starting up """
 if __name__ == '__main__':
     try:
-        main(arg=SERVER)
+        main()
     except Exception as e:
         logging.exception(e)
         sys.exit(1)

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,29 @@
-from setuptools import setup
+from setuptools import setup, find_packages
+
+with open("README.md", 'r') as f:
+    long_description = f.read()
+
+with open('requirements.txt', 'r') as f:
+    required = f.read().splitlines()
+
 
 setup(
     name='BrAPI2ISA',
+    keywords=["BrAPI", "MIAPPE", "ISA", "Phenotyping", "isa-tab"],
     url='https://github.com/elixir-europe/plant-brapi-to-isa',
+    license='BSD-3',
     packages=['.'],
-    install_requires=open('requirements.txt').read().splitlines(),
-    version='0.1',
+    long_description_content_type='text/markdown',
+    long_description=long_description,
+    install_requires=[required],
+    version='1.0',
     description='Convert BrAPI data to ISA',
-    long_description=open('README.md').read(),
+    classifiers=[
+        "Operating System :: OS Independent"
+    ],
+    python_requires='>=3.6',
+    entry_points={
+        'console_scripts': ["brapi2isa=brapi_to_isa:main"]
+    }
+
 )


### PR DESCRIPTION
- Fixing the issue in #67 
- since multiple filenames contain the observationLevel, it will give issues in windows if the observationLevel is BLOCK>PLOT, because the `>` character is not supported.  -> user is now notified
- improved the setup.py