### PR TITLE
 'Phenotyping' instead of 'nucleic acid sequencing' as protocol type

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -96,9 +96,6 @@ BrAPI v1.3 and earlier does not support all the necessary attributes that are ne
 
 Values that are supported by BrAPI but are not implemented in the given endpoint, will be filled in with `"NA in endpoint"`.
 
-## Limitations of ISA-tools
-
-Because Phenotyping is not a supported protocol in ISA-tools, we are forced to use nucleic acid sequencing as protocol_type to have an assay name column in the assay file. This is not following the MIAPPE standard, so it is needed to manually change this in the investigation file to Phenotyping.
 
 ## Validation
 The dumped ISA-tab files are automatically validated by the ISA-API using the [MIAPPE configuration files](https://github.com/MIAPPE/ISA-Tab-for-plant-phenotyping/tree/v1.1/isaconfig-phenotyping/isaconfig-phenotyping-basic). This to ensure MIAPPE compliance. Check the generated validation_log.json file for more details.
@@ -107,7 +104,7 @@ The dumped ISA-tab files are automatically validated by the ISA-API using the [M
 
 * python 3.6 +
 * following python modules:
-    * isatools v0.10.4 +
+    * isatools v0.12.0 +
     * requests
     * pycountry-convert 
     * cachetools

--- a/brapi_to_isa.py
+++ b/brapi_to_isa.py
@@ -360,7 +360,7 @@ def main(arg=SERVER):
                 # TODO: see https://github.com/ISA-tools/isa-api/blob/master/isatools/isatab.py#L886
 
                 phenotyping_protocol = Protocol(name="Phenotyping",
-                                                protocol_type=OntologyAnnotation(term="nucleic acid sequencing"))
+                                                protocol_type=OntologyAnnotation(term="Phenotyping"))
                 isa_study.protocols.append(phenotyping_protocol)
 
                 growth_protocol = Protocol(name="Growth",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-isatools==0.12.0
+isatools>=0.12.0
 requests
 pycountry-convert 
 cachetools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,4 @@
-isatools
+isatools==0.12.0
 requests
 pycountry-convert 
 cachetools
-
-# tests dependencies
-mock
-requests-mock


### PR DESCRIPTION
Since isatools 0.12.0 it is finally possible to have Phenotyping as protocol type as MIAPPE requests it

This closes #62 

I changed the requirements of the tool to have at least version 0.12.0